### PR TITLE
Implement Mechanoid wishlist features: Upsert, Aggregates, Complex WHERE, RETURNING

### DIFF
--- a/core/src/main/scala/saferis/Aggregate.scala
+++ b/core/src/main/scala/saferis/Aggregate.scala
@@ -1,0 +1,118 @@
+package saferis
+
+import zio.Trace
+
+/** Type-safe aggregate function DSL for SQL aggregate operations.
+  *
+  * Usage:
+  * {{{
+  *   // Get max sequence number with default
+  *   Query[EventRow]
+  *     .where(_.instanceId).eq(instanceId)
+  *     .selectAggregate(_.sequenceNr.max.coalesce(0L))
+  *     .queryValue[Long]
+  *
+  *   // Count all rows
+  *   Query[User]
+  *     .where(_.status).eq("active")
+  *     .selectAggregate(countAll)
+  *     .queryValue[Long]
+  * }}}
+  */
+
+// ============================================================================
+// Aggregate Function Enum
+// ============================================================================
+
+/** SQL aggregate functions */
+enum AggregateFunction(val sql: String):
+  case Max   extends AggregateFunction("max")
+  case Min   extends AggregateFunction("min")
+  case Sum   extends AggregateFunction("sum")
+  case Avg   extends AggregateFunction("avg")
+  case Count extends AggregateFunction("count")
+
+// ============================================================================
+// Aggregate Expression Types
+// ============================================================================
+
+/** Base trait for aggregate expressions */
+sealed trait AggregateExpr[T]:
+  def toSql: String
+  def writes: Seq[Write[?]]
+
+/** Aggregate function applied to a column */
+final case class ColumnAggregate[T](function: AggregateFunction, column: Column[T]) extends AggregateExpr[T]:
+  def toSql: String         = s"${function.sql}(${column.label})"
+  def writes: Seq[Write[?]] = Seq.empty
+
+  /** Wrap the aggregate in COALESCE with a default value */
+  def coalesce(default: T)(using enc: Encoder[T]): CoalesceExpr[T] =
+    CoalesceExpr(this, default, enc)
+
+/** COALESCE wrapper for aggregate expressions */
+final case class CoalesceExpr[T](expr: AggregateExpr[T], default: T, encoder: Encoder[T]) extends AggregateExpr[T]:
+  def toSql: String         = s"coalesce(${expr.toSql}, ?)"
+  def writes: Seq[Write[?]] = expr.writes :+ encoder(default)
+
+/** COUNT(*) aggregate */
+case object CountAll extends AggregateExpr[Long]:
+  def toSql: String         = "count(*)"
+  def writes: Seq[Write[?]] = Seq.empty
+
+// ============================================================================
+// Column Extensions for Aggregates
+// ============================================================================
+
+/** Extension methods to add aggregate functions to columns */
+extension [T](column: Column[T])
+  /** MAX aggregate function */
+  def max: ColumnAggregate[T] = ColumnAggregate(AggregateFunction.Max, column)
+
+  /** MIN aggregate function */
+  def min: ColumnAggregate[T] = ColumnAggregate(AggregateFunction.Min, column)
+
+  /** SUM aggregate function */
+  def sum: ColumnAggregate[T] = ColumnAggregate(AggregateFunction.Sum, column)
+
+  /** AVG aggregate function */
+  def avg: ColumnAggregate[T] = ColumnAggregate(AggregateFunction.Avg, column)
+
+  /** COUNT aggregate function (counts non-null values) */
+  def count: ColumnAggregate[Long] = ColumnAggregate(AggregateFunction.Count, column.asInstanceOf[Column[Long]])
+end extension
+
+/** Convenience function for COUNT(*) */
+def countAll: CountAll.type = CountAll
+
+// ============================================================================
+// AggregateQuery - Query returning aggregate value
+// ============================================================================
+
+/** A query that returns a single aggregate value.
+  *
+  * Created by calling `.selectAggregate(...)` on a Query1Ready.
+  */
+final case class AggregateQuery[A <: Product, T](
+    tableName: String,
+    tableAlias: Option[Alias],
+    wherePredicates: Vector[SqlFragment],
+    aggregate: AggregateExpr[T],
+):
+  /** Build the SELECT aggregate SQL */
+  def build: SqlFragment =
+    val fromClause = tableAlias.fold(tableName)(a => s"$tableName as ${a.value}")
+    var sql        = s"select ${aggregate.toSql} from $fromClause"
+
+    if wherePredicates.nonEmpty then
+      val whereJoined = Placeholder.join(wherePredicates, " and ")
+      sql = sql + s" where ${whereJoined.sql}"
+
+    val allWrites = aggregate.writes ++ wherePredicates.flatMap(_.writes)
+    SqlFragment(sql, allWrites)
+  end build
+
+  /** Execute and return the aggregate value */
+  inline def queryValue[R](using dec: Decoder[R], trace: Trace): ScopedQuery[Option[R]] =
+    build.queryValue[R]
+end AggregateQuery

--- a/core/src/main/scala/saferis/Condition.scala
+++ b/core/src/main/scala/saferis/Condition.scala
@@ -54,6 +54,22 @@ final case class LiteralCondition(
   def writes: Seq[Write[?]] = Seq(write)
 end LiteralCondition
 
+/** Condition comparing a column to the EXCLUDED pseudo-table (for upsert WHERE clauses).
+  *
+  * In PostgreSQL: `ON CONFLICT (id) DO UPDATE SET ... WHERE table.column = EXCLUDED.column`
+  */
+final case class ExcludedCondition(
+    alias: Alias,
+    column: Column[?],
+    operator: Operator,
+    excludedColumn: Column[?],
+) extends Condition:
+  def toSql: String =
+    s"${alias.toSql}.${column.label} ${operator.sql} EXCLUDED.${excludedColumn.label}"
+
+  def writes: Seq[Write[?]] = Seq.empty
+end ExcludedCondition
+
 object Condition:
   /** Convert a sequence of conditions to SQL with AND between them */
   def toSqlFragment(conditions: Seq[Condition]): SqlFragment =

--- a/core/src/main/scala/saferis/Dialect.scala
+++ b/core/src/main/scala/saferis/Dialect.scala
@@ -216,6 +216,9 @@ object Dialect:
   /** Default PostgreSQL dialect - provided as a low priority given. This allows users to work with Postgres out of the
     * box with just `import saferis.*` Users can override this by providing their own given Dialect with higher
     * priority.
+    *
+    * Using the singleton type `PostgresDialect.type` ensures this given satisfies all capability intersection types
+    * like `Dialect & UpsertSupport & ReturningSupport`.
     */
-  given defaultDialect: Dialect = postgres.PostgresDialect
+  given defaultDialect: postgres.PostgresDialect.type = postgres.PostgresDialect
 end Dialect

--- a/core/src/main/scala/saferis/DialectCapabilities.scala
+++ b/core/src/main/scala/saferis/DialectCapabilities.scala
@@ -132,6 +132,53 @@ trait UpsertSupport:
     *   SQL statement for UPSERT
     */
   def upsertSql(tableName: String, insertColumns: String, conflictColumns: Seq[String], updateColumns: String): String
+
+  /** Returns SQL for an UPSERT operation with a WHERE clause on the conflict update.
+    *
+    * Used for conditional upserts like: `ON CONFLICT (id) DO UPDATE SET ... WHERE expires_at < now()`
+    *
+    * @param tableName
+    *   Name of the table
+    * @param insertColumns
+    *   Columns for insertion
+    * @param conflictColumns
+    *   Columns that define the conflict
+    * @param updateColumns
+    *   Columns to update on conflict
+    * @param conflictWhere
+    *   Optional WHERE clause for the DO UPDATE (conditions for when to actually update)
+    * @return
+    *   SQL statement for conditional UPSERT
+    */
+  def upsertWithWhereSql(
+      tableName: String,
+      insertColumns: String,
+      conflictColumns: Seq[String],
+      updateColumns: String,
+      conflictWhere: Option[String],
+  ): String =
+    val baseUpsert  = upsertSql(tableName, insertColumns, conflictColumns, updateColumns)
+    val whereClause = conflictWhere.map(w => s" WHERE $w").getOrElse("")
+    baseUpsert + whereClause
+  end upsertWithWhereSql
+
+  /** Returns SQL for an UPSERT with DO NOTHING (insert only if no conflict).
+    *
+    * @param tableName
+    *   Name of the table
+    * @param insertColumns
+    *   Columns for insertion
+    * @param conflictColumns
+    *   Columns that define the conflict
+    * @return
+    *   SQL statement for INSERT ... ON CONFLICT DO NOTHING
+    */
+  def upsertDoNothingSql(
+      tableName: String,
+      insertColumns: String,
+      conflictColumns: Seq[String],
+  ): String
+
 end UpsertSupport
 
 /** Trait for dialects that support JSON operations */

--- a/core/src/main/scala/saferis/Upsert.scala
+++ b/core/src/main/scala/saferis/Upsert.scala
@@ -1,0 +1,420 @@
+package saferis
+
+/** Type-safe UPSERT DSL for conditional insert-or-update operations.
+  *
+  * Usage:
+  * {{{
+  *   given dialect: Dialect & UpsertSupport & ReturningSupport = PostgresDialect
+  *
+  *   // Basic upsert
+  *   Upsert[Lock]
+  *     .values(Lock(instanceId, nodeId, now, expiresAt))
+  *     .onConflict(_.instanceId)
+  *     .doUpdateAll
+  *     .build
+  *     .execute
+  *
+  *   // Conditional upsert with WHERE on conflict
+  *   Upsert[Lock]
+  *     .values(Lock(instanceId, nodeId, now, expiresAt))
+  *     .onConflict(_.instanceId)
+  *     .doUpdateAll
+  *     .where(_.expiresAt).lt(now)
+  *     .or(_.nodeId).eqExcluded  // Only update if expired OR same node
+  *     .returning
+  *     .queryOne[Lock]
+  * }}}
+  */
+object Upsert:
+  /** Create an Upsert builder for a table type */
+  inline def apply[A <: Product: Table]: UpsertBuilder[A] =
+    val table = summon[Table[A]]
+    UpsertBuilder(table.name, table.columnMap, table.columns.toVector)
+
+// ============================================================================
+// UpsertBuilder - Entry point (needs .values())
+// ============================================================================
+
+/** Initial upsert builder - needs entity values. */
+final case class UpsertBuilder[A <: Product: Table](
+    private[saferis] val tableName: String,
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val allColumns: Vector[Column[?]],
+):
+  /** Provide the entity to insert/update */
+  def values(entity: A): UpsertValuesReady[A] =
+    UpsertValuesReady(tableName, fieldNamesToColumns, allColumns, entity)
+
+// ============================================================================
+// UpsertValuesReady - Has entity, needs .onConflict()
+// ============================================================================
+
+/** Upsert builder with entity values - needs conflict columns. */
+final case class UpsertValuesReady[A <: Product: Table](
+    private[saferis] val tableName: String,
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val allColumns: Vector[Column[?]],
+    private[saferis] val entity: A,
+):
+  /** Specify the conflict column(s) for ON CONFLICT */
+  transparent inline def onConflict[T](inline selector: A => T): UpsertConflictReady[A] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = fieldNamesToColumns(fieldName)
+    UpsertConflictReady(tableName, fieldNamesToColumns, allColumns, entity, Vector(col.label))
+end UpsertValuesReady
+
+// ============================================================================
+// UpsertConflictReady - Has conflict columns, needs action (doUpdateAll/doNothing)
+// ============================================================================
+
+/** Upsert builder with conflict columns - needs update action. */
+final case class UpsertConflictReady[A <: Product: Table](
+    private[saferis] val tableName: String,
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val allColumns: Vector[Column[?]],
+    private[saferis] val entity: A,
+    private[saferis] val conflictColumns: Vector[String],
+):
+  /** Add another conflict column */
+  transparent inline def and[T](inline selector: A => T): UpsertConflictReady[A] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = fieldNamesToColumns(fieldName)
+    copy(conflictColumns = conflictColumns :+ col.label)
+
+  /** DO UPDATE SET all non-key, non-generated columns */
+  transparent inline def doUpdateAll: UpsertActionReady[A] =
+    val table         = summon[Table[A]]
+    val updateColumns = table.updateSetClause(entity)
+    UpsertActionReady(
+      tableName,
+      fieldNamesToColumns,
+      allColumns,
+      entity,
+      conflictColumns,
+      updateColumns.sql,
+      updateColumns.writes,
+      doNothing = false,
+    )
+  end doUpdateAll
+
+  /** DO NOTHING - only insert if no conflict */
+  def doNothing: UpsertDoNothingReady[A] =
+    UpsertDoNothingReady(tableName, fieldNamesToColumns, allColumns, entity, conflictColumns)
+end UpsertConflictReady
+
+// ============================================================================
+// UpsertDoNothingReady - DO NOTHING variant, ready to build
+// ============================================================================
+
+/** Upsert with DO NOTHING - ready to build. */
+final case class UpsertDoNothingReady[A <: Product: Table](
+    private[saferis] val tableName: String,
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val allColumns: Vector[Column[?]],
+    private[saferis] val entity: A,
+    private[saferis] val conflictColumns: Vector[String],
+):
+  /** Build the INSERT ... ON CONFLICT DO NOTHING SQL */
+  transparent inline def build(using dialect: Dialect & UpsertSupport): SqlFragment =
+    val table        = summon[Table[A]]
+    val insertCols   = table.insertColumnsSql.sql
+    val insertValues = table.insertPlaceholdersSql(entity)
+    val insertClause = s"$insertCols values ${insertValues.sql}"
+    val sql          = dialect.upsertDoNothingSql(tableName, insertClause, conflictColumns)
+    SqlFragment(sql, insertValues.writes)
+end UpsertDoNothingReady
+
+// ============================================================================
+// UpsertActionReady - Has DO UPDATE, can add WHERE or build
+// ============================================================================
+
+/** Upsert with DO UPDATE - can add WHERE clause or build directly. */
+final case class UpsertActionReady[A <: Product: Table](
+    private[saferis] val tableName: String,
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val allColumns: Vector[Column[?]],
+    private[saferis] val entity: A,
+    private[saferis] val conflictColumns: Vector[String],
+    private[saferis] val updateColumnsSql: String,
+    private[saferis] val updateWrites: Seq[Write[?]],
+    private[saferis] val doNothing: Boolean,
+):
+  /** Add a WHERE clause for conditional update (starts the condition) */
+  transparent inline def where[T](inline selector: A => T): UpsertWhereBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    UpsertWhereBuilder(this, Alias.unsafe(tableName), col)
+
+  /** Build without WHERE clause */
+  transparent inline def build(using dialect: Dialect & UpsertSupport): SqlFragment =
+    val table        = summon[Table[A]]
+    val insertCols   = table.insertColumnsSql.sql
+    val insertValues = table.insertPlaceholdersSql(entity)
+    val insertClause = s"$insertCols values ${insertValues.sql}"
+    val sql          = dialect.upsertSql(tableName, insertClause, conflictColumns, updateColumnsSql)
+    SqlFragment(sql, insertValues.writes ++ updateWrites)
+
+  /** Build with RETURNING clause (no WHERE) */
+  transparent inline def returning(using dialect: Dialect & UpsertSupport & ReturningSupport): ReturningQuery[A] =
+    ReturningQuery(build :+ SqlFragment(" returning *", Seq.empty))
+end UpsertActionReady
+
+// ============================================================================
+// UpsertWhereBuilder - Building WHERE condition for conflict update
+// ============================================================================
+
+/** Builder for WHERE conditions on upsert conflict update. */
+final case class UpsertWhereBuilder[A <: Product: Table, T](
+    action: UpsertActionReady[A],
+    alias: Alias,
+    column: Column[T],
+):
+  private def complete(operator: Operator, write: Write[?]): UpsertWhereReady[A] =
+    val condition = LiteralCondition(alias, column, operator, write)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    UpsertWhereReady(action, Vector(fragment))
+
+  private def completeUnary(operator: Operator): UpsertWhereReady[A] =
+    val condition = UnaryCondition(alias, column, operator)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    UpsertWhereReady(action, Vector(fragment))
+
+  /** Equals comparison */
+  def eq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Eq, enc(value))
+
+  /** Not equals comparison */
+  def neq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Neq, enc(value))
+
+  /** Less than comparison */
+  def lt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lt, enc(value))
+
+  /** Less than or equal comparison */
+  def lte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lte, enc(value))
+
+  /** Greater than comparison */
+  def gt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gt, enc(value))
+
+  /** Greater than or equal comparison */
+  def gte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gte, enc(value))
+
+  /** IS NULL check */
+  def isNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNull)
+
+  /** IS NOT NULL check */
+  def isNotNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNotNull)
+
+  /** Compare to EXCLUDED pseudo-table value (same column) */
+  def eqExcluded: UpsertWhereReady[A] =
+    val condition = ExcludedCondition(alias, column, Operator.Eq, column)
+    val fragment  = SqlFragment(condition.toSql, Seq.empty)
+    UpsertWhereReady(action, Vector(fragment))
+
+  /** Compare to EXCLUDED pseudo-table with not equal */
+  def neqExcluded: UpsertWhereReady[A] =
+    val condition = ExcludedCondition(alias, column, Operator.Neq, column)
+    val fragment  = SqlFragment(condition.toSql, Seq.empty)
+    UpsertWhereReady(action, Vector(fragment))
+
+end UpsertWhereBuilder
+
+// ============================================================================
+// UpsertWhereReady - Has WHERE, can add more conditions or build
+// ============================================================================
+
+/** Upsert with WHERE clause - can chain more conditions or build. */
+final case class UpsertWhereReady[A <: Product: Table](
+    private[saferis] val action: UpsertActionReady[A],
+    private[saferis] val wherePredicates: Vector[SqlFragment],
+):
+  /** Chain with OR */
+  transparent inline def or[T](inline selector: A => T): UpsertOrBuilder[A, T] =
+    UpsertWhereReady.chainOr(this, selector)
+
+  /** Chain with AND */
+  transparent inline def and[T](inline selector: A => T): UpsertAndBuilder[A, T] =
+    UpsertWhereReady.chainAnd(this, selector)
+
+  /** Build the complete upsert SQL */
+  transparent inline def build(using dialect: Dialect & UpsertSupport): SqlFragment =
+    val table        = summon[Table[A]]
+    val insertCols   = table.insertColumnsSql.sql
+    val insertValues = table.insertPlaceholdersSql(action.entity)
+    val insertClause = s"$insertCols values ${insertValues.sql}"
+
+    // Build WHERE clause from predicates
+    val whereJoined = if wherePredicates.nonEmpty then
+      val joined = Placeholder.join(wherePredicates, " OR ")
+      Some(joined.sql)
+    else None
+
+    val sql = dialect.upsertWithWhereSql(
+      action.tableName,
+      insertClause,
+      action.conflictColumns,
+      action.updateColumnsSql,
+      whereJoined,
+    )
+
+    val allWrites = insertValues.writes ++ action.updateWrites ++ wherePredicates.flatMap(_.writes)
+    SqlFragment(sql, allWrites)
+  end build
+
+  /** Build with RETURNING clause */
+  transparent inline def returning(using dialect: Dialect & UpsertSupport & ReturningSupport): ReturningQuery[A] =
+    ReturningQuery(build :+ SqlFragment(" returning *", Seq.empty))
+
+end UpsertWhereReady
+
+object UpsertWhereReady:
+  inline def chainOr[A <: Product: Table, T](
+      ready: UpsertWhereReady[A],
+      inline selector: A => T,
+  ): UpsertOrBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = ready.action.fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    UpsertOrBuilder(ready, Alias.unsafe(ready.action.tableName), col)
+
+  inline def chainAnd[A <: Product: Table, T](
+      ready: UpsertWhereReady[A],
+      inline selector: A => T,
+  ): UpsertAndBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = ready.action.fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    UpsertAndBuilder(ready, Alias.unsafe(ready.action.tableName), col)
+end UpsertWhereReady
+
+// ============================================================================
+// UpsertOrBuilder - Building OR condition
+// ============================================================================
+
+/** Builder for OR conditions in upsert WHERE clause. */
+final case class UpsertOrBuilder[A <: Product: Table, T](
+    ready: UpsertWhereReady[A],
+    alias: Alias,
+    column: Column[T],
+):
+  private def complete(operator: Operator, write: Write[?]): UpsertWhereReady[A] =
+    val condition = LiteralCondition(alias, column, operator, write)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+  private def completeUnary(operator: Operator): UpsertWhereReady[A] =
+    val condition = UnaryCondition(alias, column, operator)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+  /** Equals comparison */
+  def eq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Eq, enc(value))
+
+  /** Not equals comparison */
+  def neq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Neq, enc(value))
+
+  /** Less than comparison */
+  def lt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lt, enc(value))
+
+  /** Less than or equal comparison */
+  def lte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lte, enc(value))
+
+  /** Greater than comparison */
+  def gt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gt, enc(value))
+
+  /** Greater than or equal comparison */
+  def gte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gte, enc(value))
+
+  /** IS NULL check */
+  def isNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNull)
+
+  /** IS NOT NULL check */
+  def isNotNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNotNull)
+
+  /** Compare to EXCLUDED pseudo-table value (same column) */
+  def eqExcluded: UpsertWhereReady[A] =
+    val condition = ExcludedCondition(alias, column, Operator.Eq, column)
+    val fragment  = SqlFragment(condition.toSql, Seq.empty)
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+  /** Compare to EXCLUDED pseudo-table with not equal */
+  def neqExcluded: UpsertWhereReady[A] =
+    val condition = ExcludedCondition(alias, column, Operator.Neq, column)
+    val fragment  = SqlFragment(condition.toSql, Seq.empty)
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+end UpsertOrBuilder
+
+// ============================================================================
+// UpsertAndBuilder - Building AND condition
+// ============================================================================
+
+/** Builder for AND conditions in upsert WHERE clause. */
+final case class UpsertAndBuilder[A <: Product: Table, T](
+    ready: UpsertWhereReady[A],
+    alias: Alias,
+    column: Column[T],
+):
+  private def complete(operator: Operator, write: Write[?]): UpsertWhereReady[A] =
+    // For AND, we need to group the current predicates and add a new one
+    // This is simplified - full implementation would track AND/OR grouping
+    val condition = LiteralCondition(alias, column, operator, write)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+  private def completeUnary(operator: Operator): UpsertWhereReady[A] =
+    val condition = UnaryCondition(alias, column, operator)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+  /** Equals comparison */
+  def eq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Eq, enc(value))
+
+  /** Not equals comparison */
+  def neq(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Neq, enc(value))
+
+  /** Less than comparison */
+  def lt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lt, enc(value))
+
+  /** Less than or equal comparison */
+  def lte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Lte, enc(value))
+
+  /** Greater than comparison */
+  def gt(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gt, enc(value))
+
+  /** Greater than or equal comparison */
+  def gte(value: T)(using enc: Encoder[T]): UpsertWhereReady[A] =
+    complete(Operator.Gte, enc(value))
+
+  /** IS NULL check */
+  def isNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNull)
+
+  /** IS NOT NULL check */
+  def isNotNull: UpsertWhereReady[A] =
+    completeUnary(Operator.IsNotNull)
+
+  /** Compare to EXCLUDED pseudo-table value (same column) */
+  def eqExcluded: UpsertWhereReady[A] =
+    val condition = ExcludedCondition(alias, column, Operator.Eq, column)
+    val fragment  = SqlFragment(condition.toSql, Seq.empty)
+    ready.copy(wherePredicates = ready.wherePredicates :+ fragment)
+
+end UpsertAndBuilder

--- a/core/src/main/scala/saferis/WhereGroup.scala
+++ b/core/src/main/scala/saferis/WhereGroup.scala
@@ -1,0 +1,253 @@
+package saferis
+
+/** Represents a group of conditions that can be combined with AND/OR.
+  *
+  * Used with `.andWhere` for complex conditions like: `.andWhere(w => w(_.status).isNull.or(_.expired).eq(true))`
+  *
+  * Generates SQL with proper parentheses: `(status IS NULL OR expired = ?)`
+  */
+sealed trait WhereGroup:
+  /** Generate the SQL fragment for this condition group */
+  def toSqlFragment: SqlFragment
+
+/** A single condition (leaf node) */
+final case class SingleCondition(fragment: SqlFragment) extends WhereGroup:
+  def toSqlFragment: SqlFragment = fragment
+
+/** OR group: combines conditions with OR, wrapped in parentheses.
+  *
+  * Example: `(a OR b OR c)`
+  */
+final case class OrGroup(conditions: Vector[WhereGroup]) extends WhereGroup:
+  def toSqlFragment: SqlFragment =
+    if conditions.isEmpty then SqlFragment("", Seq.empty)
+    else
+      val parts  = conditions.map(_.toSqlFragment)
+      val joined = Placeholder.join(parts, " OR ")
+      val writes = parts.flatMap(_.writes)
+      SqlFragment(s"(${joined.sql})", writes)
+
+/** AND group: combines conditions with AND, wrapped in parentheses.
+  *
+  * Example: `(a AND b AND c)`
+  */
+final case class AndGroup(conditions: Vector[WhereGroup]) extends WhereGroup:
+  def toSqlFragment: SqlFragment =
+    if conditions.isEmpty then SqlFragment("", Seq.empty)
+    else
+      val parts  = conditions.map(_.toSqlFragment)
+      val joined = Placeholder.join(parts, " AND ")
+      val writes = parts.flatMap(_.writes)
+      SqlFragment(s"(${joined.sql})", writes)
+
+// ============================================================================
+// WhereGroupBuilder - Entry point for grouped conditions
+// ============================================================================
+
+/** Builder for creating grouped WHERE conditions within a lambda.
+  *
+  * Usage:
+  * {{{
+  *   Query[User]
+  *     .where(_.active).eq(true)
+  *     .andWhere(w => w(_.status).isNull.or(_.deletedAt).isNotNull)
+  *     .query[User]
+  * }}}
+  *
+  * Generates: `WHERE active = ? AND (status IS NULL OR deleted_at IS NOT NULL)`
+  */
+final case class WhereGroupBuilder[A <: Product](
+    private[saferis] val fieldNamesToColumns: Map[String, Column[?]],
+    private[saferis] val tableAlias: Alias,
+)(using Table[A]):
+  /** Start a condition on a column: `w(_.field)` */
+  inline def apply[T](inline selector: A => T): WhereGroupColumnBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    WhereGroupColumnBuilder(this, tableAlias, col)
+
+// ============================================================================
+// WhereGroupColumnBuilder - Building a single condition
+// ============================================================================
+
+/** Builds a single condition within a group.
+  *
+  * After completing (e.g., `.eq(value)`), returns a WhereGroupChain that allows `.or()` or `.and()` chaining.
+  */
+final case class WhereGroupColumnBuilder[A <: Product: Table, T](
+    builder: WhereGroupBuilder[A],
+    alias: Alias,
+    column: Column[T],
+):
+  private def complete(operator: Operator, write: Write[?]): WhereGroupChain[A] =
+    val condition = LiteralCondition(alias, column, operator, write)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    WhereGroupChain(builder, SingleCondition(fragment))
+
+  private def completeUnary(operator: Operator): WhereGroupChain[A] =
+    val condition = UnaryCondition(alias, column, operator)
+    val fragment  = Condition.toSqlFragment(Vector(condition))
+    WhereGroupChain(builder, SingleCondition(fragment))
+
+  /** Equals comparison */
+  def eq(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Eq, enc(value))
+
+  /** Not equals comparison */
+  def neq(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Neq, enc(value))
+
+  /** Less than comparison */
+  def lt(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Lt, enc(value))
+
+  /** Less than or equal comparison */
+  def lte(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Lte, enc(value))
+
+  /** Greater than comparison */
+  def gt(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Gt, enc(value))
+
+  /** Greater than or equal comparison */
+  def gte(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Gte, enc(value))
+
+  /** IS NULL check */
+  def isNull: WhereGroupChain[A] =
+    completeUnary(Operator.IsNull)
+
+  /** IS NOT NULL check */
+  def isNotNull: WhereGroupChain[A] =
+    completeUnary(Operator.IsNotNull)
+
+  /** Custom operator */
+  def op(operator: Operator)(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(operator, enc(value))
+
+end WhereGroupColumnBuilder
+
+// ============================================================================
+// WhereGroupChain - Allows chaining with .or() or .and()
+// ============================================================================
+
+/** Chain for building complex conditions with OR/AND.
+  *
+  * After completing a condition, use `.or(_.field)` or `.and(_.field)` to add more conditions.
+  */
+final case class WhereGroupChain[A <: Product: Table](
+    builder: WhereGroupBuilder[A],
+    group: WhereGroup,
+):
+  /** Chain with OR: `w(_.a).eq(1).or(_.b).eq(2)` produces `(a = ? OR b = ?)` */
+  transparent inline def or[T](inline selector: A => T): WhereGroupOrBuilder[A, T] =
+    WhereGroupChain.chainOr(this, selector)
+
+  /** Chain with AND: `w(_.a).eq(1).and(_.b).eq(2)` produces `(a = ? AND b = ?)` */
+  transparent inline def and[T](inline selector: A => T): WhereGroupOrBuilder[A, T] =
+    WhereGroupChain.chainAnd(this, selector)
+
+  /** Get the underlying WhereGroup for building SQL */
+  def toWhereGroup: WhereGroup = group
+
+end WhereGroupChain
+
+object WhereGroupChain:
+  inline def chainOr[A <: Product: Table, T](
+      chain: WhereGroupChain[A],
+      inline selector: A => T,
+  ): WhereGroupOrBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = chain.builder.fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    WhereGroupOrBuilder(chain.builder, chain.builder.tableAlias, col, chain.group, isOr = true)
+
+  inline def chainAnd[A <: Product: Table, T](
+      chain: WhereGroupChain[A],
+      inline selector: A => T,
+  ): WhereGroupOrBuilder[A, T] =
+    val fieldName = Macros.extractFieldName[A, T](selector)
+    val col       = chain.builder.fieldNamesToColumns(fieldName).asInstanceOf[Column[T]]
+    WhereGroupOrBuilder(chain.builder, chain.builder.tableAlias, col, chain.group, isOr = false)
+end WhereGroupChain
+
+// ============================================================================
+// WhereGroupOrBuilder - Continues chain after .or() or .and()
+// ============================================================================
+
+/** Builder for the next condition after `.or()` or `.and()`. */
+final case class WhereGroupOrBuilder[A <: Product: Table, T](
+    builder: WhereGroupBuilder[A],
+    alias: Alias,
+    column: Column[T],
+    previous: WhereGroup,
+    isOr: Boolean,
+):
+  private def complete(operator: Operator, write: Write[?]): WhereGroupChain[A] =
+    val condition    = LiteralCondition(alias, column, operator, write)
+    val fragment     = Condition.toSqlFragment(Vector(condition))
+    val newCondition = SingleCondition(fragment)
+    val combined     =
+      if isOr then
+        previous match
+          case OrGroup(conds) => OrGroup(conds :+ newCondition)
+          case other          => OrGroup(Vector(other, newCondition))
+      else
+        previous match
+          case AndGroup(conds) => AndGroup(conds :+ newCondition)
+          case other           => AndGroup(Vector(other, newCondition))
+    WhereGroupChain(builder, combined)
+  end complete
+
+  private def completeUnary(operator: Operator): WhereGroupChain[A] =
+    val condition    = UnaryCondition(alias, column, operator)
+    val fragment     = Condition.toSqlFragment(Vector(condition))
+    val newCondition = SingleCondition(fragment)
+    val combined     =
+      if isOr then
+        previous match
+          case OrGroup(conds) => OrGroup(conds :+ newCondition)
+          case other          => OrGroup(Vector(other, newCondition))
+      else
+        previous match
+          case AndGroup(conds) => AndGroup(conds :+ newCondition)
+          case other           => AndGroup(Vector(other, newCondition))
+    WhereGroupChain(builder, combined)
+  end completeUnary
+
+  /** Equals comparison */
+  def eq(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Eq, enc(value))
+
+  /** Not equals comparison */
+  def neq(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Neq, enc(value))
+
+  /** Less than comparison */
+  def lt(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Lt, enc(value))
+
+  /** Less than or equal comparison */
+  def lte(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Lte, enc(value))
+
+  /** Greater than comparison */
+  def gt(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Gt, enc(value))
+
+  /** Greater than or equal comparison */
+  def gte(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(Operator.Gte, enc(value))
+
+  /** IS NULL check */
+  def isNull: WhereGroupChain[A] =
+    completeUnary(Operator.IsNull)
+
+  /** IS NOT NULL check */
+  def isNotNull: WhereGroupChain[A] =
+    completeUnary(Operator.IsNotNull)
+
+  /** Custom operator */
+  def op(operator: Operator)(value: T)(using enc: Encoder[T]): WhereGroupChain[A] =
+    complete(operator, enc(value))
+
+end WhereGroupOrBuilder

--- a/core/src/main/scala/saferis/postgres/PostgresDialect.scala
+++ b/core/src/main/scala/saferis/postgres/PostgresDialect.scala
@@ -4,7 +4,8 @@ import saferis.*
 
 import java.sql.Types
 
-given Dialect = PostgresDialect
+// Export PostgresDialect with its singleton type so all capability intersections are satisfied
+given PostgresDialect.type = PostgresDialect
 
 /** PostgreSQL dialect implementation providing PostgreSQL-specific type mappings and SQL generation */
 object PostgresDialect
@@ -74,6 +75,9 @@ object PostgresDialect
   // === UpsertSupport implementation ===
   def upsertSql(tableName: String, insertColumns: String, conflictColumns: Seq[String], updateColumns: String): String =
     s"insert into $tableName $insertColumns on conflict (${conflictColumns.mkString(", ")}) do update set $updateColumns"
+
+  def upsertDoNothingSql(tableName: String, insertColumns: String, conflictColumns: Seq[String]): String =
+    s"insert into $tableName $insertColumns on conflict (${conflictColumns.mkString(", ")}) do nothing"
 
   // === JsonSupport implementation ===
   def jsonType: String = "jsonb"

--- a/core/src/test/scala/saferis/tests/AggregateSpecs.scala
+++ b/core/src/test/scala/saferis/tests/AggregateSpecs.scala
@@ -1,0 +1,195 @@
+package saferis.tests
+
+import saferis.*
+import saferis.tests.PostgresTestContainer.DataSourceProvider
+import zio.*
+import zio.test.*
+
+object AggregateSpecs extends ZIOSpecDefault:
+  val xaLayer = DataSourceProvider.default >>> Transactor.default
+
+  // Test table for aggregates
+  @tableName("aggregate_test")
+  final case class EventRow(
+      @generated @key id: Int,
+      @label("instance_id") instanceId: String,
+      @label("sequence_nr") sequenceNr: Long,
+      amount: BigDecimal,
+  ) derives Table
+
+  // ============================================================================
+  // SQL Generation Tests (Unit Tests)
+  // ============================================================================
+
+  val sqlGenerationTests = suite("SQL Generation")(
+    suite("Basic Aggregates")(
+      test("max generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.sequenceNr)(_.max)
+          .build
+        assertTrue(frag.sql.contains("select max(sequence_nr) from aggregate_test")) &&
+        assertTrue(frag.sql.contains("where"))
+      ,
+      test("min generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.sequenceNr)(_.min)
+          .build
+        assertTrue(frag.sql.contains("select min(sequence_nr) from aggregate_test"))
+      ,
+      test("sum generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.amount)(_.sum)
+          .build
+        assertTrue(frag.sql.contains("select sum(amount) from aggregate_test"))
+      ,
+      test("count generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.sequenceNr)(_.count)
+          .build
+        assertTrue(frag.sql.contains("select count(sequence_nr) from aggregate_test"))
+      ,
+      test("countAll generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(countAll)
+          .build
+        assertTrue(frag.sql.contains("select count(*) from aggregate_test")),
+    ),
+    suite("COALESCE")(
+      test("max with coalesce generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.sequenceNr)(_.max.coalesce(0L))
+          .build
+        assertTrue(frag.sql.contains("select coalesce(max(sequence_nr), ?) from aggregate_test")) &&
+        assertTrue(frag.writes.size == 2) // instanceId + default value
+      ,
+      test("sum with coalesce generates correct SQL"):
+        val frag = Query[EventRow]
+          .where(_.instanceId)
+          .eq("test-1")
+          .selectAggregate(_.amount)(_.sum.coalesce(BigDecimal(0)))
+          .build
+        assertTrue(frag.sql.contains("select coalesce(sum(amount), ?) from aggregate_test")),
+    ),
+  )
+
+  // ============================================================================
+  // Integration Tests (with PostgreSQL)
+  // ============================================================================
+
+  val integrationTests = suite("Integration")(
+    test("max returns correct value"):
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[EventRow]())
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 1L, BigDecimal(100))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 5L, BigDecimal(200))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 3L, BigDecimal(150))))
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("test-1")
+            .selectAggregate(_.sequenceNr)(_.max)
+            .queryValue[Long]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(5L))
+    ,
+    test("min returns correct value"):
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[EventRow]())
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 1L, BigDecimal(100))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 5L, BigDecimal(200))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 3L, BigDecimal(150))))
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("test-1")
+            .selectAggregate(_.sequenceNr)(_.min)
+            .queryValue[Long]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(1L))
+    ,
+    test("sum returns correct value"):
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[EventRow]())
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 1L, BigDecimal(100))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 2L, BigDecimal(200))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 3L, BigDecimal(150))))
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("test-1")
+            .selectAggregate(_.amount)(_.sum)
+            .queryValue[BigDecimal]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(BigDecimal(450)))
+    ,
+    test("count returns correct value"):
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[EventRow]())
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 1L, BigDecimal(100))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 2L, BigDecimal(200))))
+        _      <- xa.run(dml.insert(EventRow(-1, "test-2", 1L, BigDecimal(50))))
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("test-1")
+            .selectAggregate(countAll)
+            .queryValue[Long]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(2L))
+    ,
+    test("max with coalesce returns default for empty result"):
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[EventRow]())
+        // No rows for "nonexistent"
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("nonexistent")
+            .selectAggregate(_.sequenceNr)(_.max.coalesce(0L))
+            .queryValue[Long]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(0L))
+    ,
+    test("max with coalesce returns actual value when rows exist"):
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[EventRow]())
+        _      <- xa.run(dml.insert(EventRow(-1, "test-1", 42L, BigDecimal(100))))
+        result <- xa.run(
+          Query[EventRow]
+            .where(_.instanceId)
+            .eq("test-1")
+            .selectAggregate(_.sequenceNr)(_.max.coalesce(0L))
+            .queryValue[Long]
+        )
+        _ <- xa.run(ddl.dropTable[EventRow]())
+      yield assertTrue(result.contains(42L)),
+  ).provideShared(xaLayer) @@ TestAspect.sequential
+
+  override def spec = suite("AggregateSpecs")(
+    sqlGenerationTests,
+    integrationTests,
+  )
+end AggregateSpecs

--- a/core/src/test/scala/saferis/tests/UpsertSpecs.scala
+++ b/core/src/test/scala/saferis/tests/UpsertSpecs.scala
@@ -1,0 +1,257 @@
+package saferis.tests
+
+import saferis.*
+import saferis.tests.PostgresTestContainer.DataSourceProvider
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+object UpsertSpecs extends ZIOSpecDefault:
+  val xaLayer = DataSourceProvider.default >>> Transactor.default
+
+  // Test table for upsert - simulates a lock/lease table
+  @tableName("upsert_locks")
+  final case class LockRow(
+      @key @label("instance_id") instanceId: String,
+      @label("node_id") nodeId: String,
+      @label("acquired_at") acquiredAt: Instant,
+      @label("expires_at") expiresAt: Instant,
+  ) derives Table
+
+  // ============================================================================
+  // SQL Generation Tests (Unit Tests)
+  // ============================================================================
+
+  val sqlGenerationTests = suite("SQL Generation")(
+    suite("Basic Upsert")(
+      test("doUpdateAll generates correct SQL"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val frag   = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .doUpdateAll
+          .build
+        assertTrue(frag.sql.contains("insert into upsert_locks")) &&
+        assertTrue(frag.sql.contains("on conflict (instance_id)")) &&
+        assertTrue(frag.sql.contains("do update set")) &&
+        assertTrue(frag.sql.contains("node_id = ?"))
+      ,
+      test("doNothing generates correct SQL"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val frag   = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .doNothing
+          .build
+        assertTrue(frag.sql.contains("insert into upsert_locks")) &&
+        assertTrue(frag.sql.contains("on conflict (instance_id)")) &&
+        assertTrue(frag.sql.contains("do nothing"))
+      ,
+      test("compound conflict columns"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val frag   = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .and(_.nodeId)
+          .doUpdateAll
+          .build
+        assertTrue(frag.sql.contains("on conflict (instance_id, node_id)")),
+    ),
+    suite("Conditional Upsert")(
+      test("WHERE clause on conflict"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val frag   = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .doUpdateAll
+          .where(_.expiresAt)
+          .lt(now)
+          .build
+        assertTrue(frag.sql.contains("on conflict (instance_id)")) &&
+        assertTrue(frag.sql.contains("do update set")) &&
+        assertTrue(frag.sql.contains("WHERE")) &&
+        assertTrue(frag.sql.contains("expires_at < ?"))
+      ,
+      test("OR condition with eqExcluded"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val frag   = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .doUpdateAll
+          .where(_.expiresAt)
+          .lt(now)
+          .or(_.nodeId)
+          .eqExcluded
+          .build
+        assertTrue(frag.sql.contains("WHERE")) &&
+        assertTrue(frag.sql.contains("expires_at < ?")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("node_id = EXCLUDED.node_id"))
+      ,
+      test("RETURNING clause"):
+        val now    = Instant.now()
+        val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+        val query  = Upsert[LockRow]
+          .values(entity)
+          .onConflict(_.instanceId)
+          .doUpdateAll
+          .where(_.expiresAt)
+          .lt(now)
+          .or(_.nodeId)
+          .eqExcluded
+          .returning
+        assertTrue(query.build.sql.contains("returning *")),
+    ),
+  )
+
+  // ============================================================================
+  // Integration Tests (with PostgreSQL)
+  // ============================================================================
+
+  val integrationTests = suite("Integration")(
+    test("basic upsert inserts new row"):
+      val now    = Instant.now()
+      val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[LockRow]())
+        // First insert
+        _ <- xa.run(Upsert[LockRow].values(entity).onConflict(_.instanceId).doUpdateAll.build.dml)
+        // Verify
+        results <- xa.run(Query[LockRow].where(_.instanceId).eq("instance-1").query[LockRow])
+        _       <- xa.run(ddl.dropTable[LockRow]())
+      yield assertTrue(results.size == 1) &&
+        assertTrue(results.head.nodeId == "node-1")
+      end for
+    ,
+    test("basic upsert updates existing row"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[LockRow]())
+        // First insert
+        _ <- xa.run(dml.insert(LockRow("instance-1", "node-1", now, now.plusSeconds(60))))
+        // Upsert with different nodeId
+        _ <- xa.run(
+          Upsert[LockRow]
+            .values(LockRow("instance-1", "node-2", now.plusSeconds(10), now.plusSeconds(120)))
+            .onConflict(_.instanceId)
+            .doUpdateAll
+            .build
+            .dml
+        )
+        // Verify - should be updated
+        results <- xa.run(Query[LockRow].where(_.instanceId).eq("instance-1").query[LockRow])
+        _       <- xa.run(ddl.dropTable[LockRow]())
+      yield assertTrue(results.size == 1) &&
+        assertTrue(results.head.nodeId == "node-2")
+      end for
+    ,
+    test("conditional upsert only updates when condition met"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[LockRow]())
+        // Insert with future expiry (not expired)
+        _ <- xa.run(dml.insert(LockRow("instance-1", "node-1", now, now.plusSeconds(600))))
+        // Try to upsert with condition that expiry < now (should NOT update because not expired)
+        count <- xa.run(
+          Upsert[LockRow]
+            .values(LockRow("instance-1", "node-2", now.plusSeconds(10), now.plusSeconds(120)))
+            .onConflict(_.instanceId)
+            .doUpdateAll
+            .where(_.expiresAt)
+            .lt(now)
+            .build
+            .dml
+        )
+        // Verify - should still have original values
+        results <- xa.run(Query[LockRow].where(_.instanceId).eq("instance-1").query[LockRow])
+        _       <- xa.run(ddl.dropTable[LockRow]())
+      yield assertTrue(count == 0) && // No rows affected because condition not met
+        assertTrue(results.head.nodeId == "node-1")
+      end for
+    ,
+    test("conditional upsert with OR nodeId = EXCLUDED.nodeId"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[LockRow]())
+        // Insert with future expiry (not expired) but same node
+        _ <- xa.run(dml.insert(LockRow("instance-1", "node-1", now, now.plusSeconds(600))))
+        // Upsert with same node - should update because nodeId matches EXCLUDED
+        count <- xa.run(
+          Upsert[LockRow]
+            .values(LockRow("instance-1", "node-1", now.plusSeconds(10), now.plusSeconds(120)))
+            .onConflict(_.instanceId)
+            .doUpdateAll
+            .where(_.expiresAt)
+            .lt(now)
+            .or(_.nodeId)
+            .eqExcluded
+            .build
+            .dml
+        )
+        // Verify - should be updated because nodeId = EXCLUDED.nodeId
+        results <- xa.run(Query[LockRow].where(_.instanceId).eq("instance-1").query[LockRow])
+        _       <- xa.run(ddl.dropTable[LockRow]())
+      yield assertTrue(count == 1) && // Updated because same node
+        assertTrue(results.head.expiresAt.isAfter(now.plusSeconds(100)))
+      end for
+    ,
+    test("upsert with returning"):
+      val now    = Instant.now()
+      val entity = LockRow("instance-1", "node-1", now, now.plusSeconds(60))
+      for
+        xa     <- ZIO.service[Transactor]
+        _      <- xa.run(ddl.createTable[LockRow]())
+        result <- xa.run(
+          Upsert[LockRow]
+            .values(entity)
+            .onConflict(_.instanceId)
+            .doUpdateAll
+            .returning
+            .queryOne
+        )
+        _ <- xa.run(ddl.dropTable[LockRow]())
+      yield assertTrue(result.isDefined) &&
+        assertTrue(result.get.instanceId == "instance-1")
+      end for
+    ,
+    test("doNothing ignores conflict"):
+      val now = Instant.now()
+      val res =
+        for
+          xa <- ZIO.service[Transactor]
+          _  <- xa.run(ddl.createTable[LockRow]())
+          // First insert
+          _ <- xa.run(dml.insert(LockRow("instance-1", "node-1", now, now.plusSeconds(60))))
+          // Try to insert with DO NOTHING - should be ignored
+          count <- xa.run(
+            Upsert[LockRow]
+              .values(LockRow("instance-1", "node-2", now.plusSeconds(10), now.plusSeconds(120)))
+              .onConflict(_.instanceId)
+              .doNothing
+              .build
+              .dml
+          )
+          // Verify - should still have original values
+          results <- xa.run(Query[LockRow].where(_.instanceId).eq("instance-1").query[LockRow])
+          _       <- xa.run(ddl.dropTable[LockRow]())
+        yield assertTrue(count == 0) && // No rows affected (conflict ignored)
+          assertTrue(results.head.nodeId == "node-1")
+      end res
+      res,
+  ).provideShared(xaLayer) @@ TestAspect.sequential
+
+  override def spec = suite("UpsertSpecs")(
+    sqlGenerationTests,
+    integrationTests,
+  )
+end UpsertSpecs

--- a/core/src/test/scala/saferis/tests/WhereGroupSpecs.scala
+++ b/core/src/test/scala/saferis/tests/WhereGroupSpecs.scala
@@ -1,0 +1,271 @@
+package saferis.tests
+
+import saferis.*
+import saferis.tests.PostgresTestContainer.DataSourceProvider
+import zio.*
+import zio.test.*
+
+import java.time.Instant
+
+object WhereGroupSpecs extends ZIOSpecDefault:
+  val xaLayer = DataSourceProvider.default >>> Transactor.default
+
+  // Test table with non-Option types for comparison tests
+  @tableName("where_group_test")
+  final case class TestRow(
+      @generated @key id: Int,
+      status: String,
+      @label("claimed_by") claimedBy: String,
+      @label("claimed_until") claimedUntil: Instant,
+      deadline: Instant,
+      priority: Int,
+      active: Boolean,
+  ) derives Table
+
+  // Table with Option fields for IS NULL tests
+  @tableName("where_group_nullable")
+  final case class NullableRow(
+      @generated @key id: Int,
+      status: Option[String],
+      @label("claimed_by") claimedBy: Option[String],
+      @label("claimed_until") claimedUntil: Option[Instant],
+      deadline: Instant,
+      active: Boolean,
+  ) derives Table
+
+  // ============================================================================
+  // SQL Generation Tests (Unit Tests)
+  // ============================================================================
+
+  val sqlGenerationTests = suite("SQL Generation")(
+    suite("WhereGroup")(
+      test("single condition generates correct SQL"):
+        val sql = Query[TestRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.status).eq("pending"))
+          .build
+          .sql
+        assertTrue(sql.contains("active = ?")) &&
+        assertTrue(sql.contains("and")) &&
+        assertTrue(sql.contains("status = ?"))
+      ,
+      test("OR condition with same type generates parenthesized SQL"):
+        val frag = Query[TestRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.status).eq("pending").or(_.status).eq("active"))
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("status = ?"))
+      ,
+      test("OR with different columns different types generates correct SQL"):
+        val now  = Instant.now()
+        val frag = Query[TestRow]
+          .where(_.deadline)
+          .lte(now)
+          .andWhere(w => w(_.status).eq("pending").or(_.claimedUntil).lt(now))
+          .build
+        assertTrue(frag.sql.contains("deadline <= ?")) &&
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains("status = ?")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("claimed_until < ?")) &&
+        assertTrue(frag.writes.size == 3) // deadline + status + claimedUntil
+      ,
+      test("multiple OR conditions chain correctly"):
+        val frag = Query[TestRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.status).eq("pending").or(_.status).eq("active").or(_.status).eq("retry"))
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.count(_ == '?') == 4) && // active + 3 status values
+        assertTrue(frag.writes.size == 4)
+      ,
+      test("AND within group generates correct SQL"):
+        val frag = Query[TestRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.status).eq("claimed").and(_.claimedBy).eq("node-1"))
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains(" AND ")) &&
+        assertTrue(frag.sql.contains("status = ?")) &&
+        assertTrue(frag.sql.contains("claimed_by = ?"))
+      ,
+      test("IS NULL in group generates correct SQL"):
+        val frag = Query[NullableRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.status).isNull.or(_.claimedBy).isNotNull)
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains("status IS NULL")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("claimed_by IS NOT NULL"))
+      ,
+      test("numeric OR condition"):
+        val frag = Query[TestRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.priority).lt(5).or(_.priority).gt(10))
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains("priority < ?")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("priority > ?"))
+      ,
+      test("mixed types in OR chain - string and instant"):
+        val now  = Instant.now()
+        val frag = Query[NullableRow]
+          .where(_.active)
+          .eq(true)
+          .andWhere(w => w(_.claimedBy).isNull.or(_.claimedUntil).lt(Some(now)))
+          .build
+        assertTrue(frag.sql.contains("(")) &&
+        assertTrue(frag.sql.contains("claimed_by IS NULL")) &&
+        assertTrue(frag.sql.contains(" OR ")) &&
+        assertTrue(frag.sql.contains("claimed_until < ?")),
+    ),
+    suite("Update andWhere")(
+      test("Update with andWhere generates correct SQL"):
+        val now  = Instant.now()
+        val frag = Update[TestRow]
+          .set(_.claimedBy, "node-1")
+          .set(_.claimedUntil, now)
+          .where(_.id)
+          .eq(123)
+          .andWhere(w => w(_.status).eq("pending").or(_.claimedUntil).lt(now))
+          .build
+        assertTrue(frag.sql.contains("update where_group_test set")) &&
+        assertTrue(frag.sql.contains("where")) &&
+        assertTrue(frag.sql.contains("id = ?")) &&
+        assertTrue(frag.sql.contains("status = ? OR")) &&
+        assertTrue(frag.sql.contains("claimed_until < ?"))
+    ),
+    suite("Delete andWhere")(
+      test("Delete with andWhere generates correct SQL"):
+        val frag = Delete[TestRow]
+          .where(_.active)
+          .eq(false)
+          .andWhere(w => w(_.status).eq("deleted").or(_.claimedBy).eq(""))
+          .build
+        assertTrue(frag.sql.contains("delete from where_group_test")) &&
+        assertTrue(frag.sql.contains("where")) &&
+        assertTrue(frag.sql.contains("active = ?")) &&
+        assertTrue(frag.sql.contains("status = ? OR")) &&
+        assertTrue(frag.sql.contains("claimed_by = ?"))
+    ),
+  )
+
+  // ============================================================================
+  // Integration Tests (with PostgreSQL)
+  // ============================================================================
+
+  val integrationTests = suite("Integration")(
+    test("Query with andWhere executes correctly"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[TestRow]())
+        // Insert test data
+        _ <- xa.run(
+          dml.insert(TestRow(-1, "active", "node-1", now.plusSeconds(60), now, 1, true))
+        )
+        _ <- xa.run(dml.insert(TestRow(-1, "pending", "", now, now.minusSeconds(60), 2, true)))
+        _ <- xa.run(
+          dml.insert(TestRow(-1, "expired", "node-2", now.minusSeconds(60), now, 3, false))
+        )
+        // Query using andWhere: active AND (status = 'pending' OR status = 'expired')
+        results <- xa.run(
+          Query[TestRow]
+            .where(_.active)
+            .eq(true)
+            .andWhere(w => w(_.status).eq("pending").or(_.status).eq("expired"))
+            .query[TestRow]
+        )
+        _ <- xa.run(ddl.dropTable[TestRow]())
+      yield assertTrue(results.size == 1) && // Only the pending row (active=true)
+        assertTrue(results.head.status == "pending")
+      end for
+    ,
+    test("Query with mixed type OR condition"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[TestRow]())
+        // Insert test data
+        _ <- xa.run(dml.insert(TestRow(-1, "pending", "", now.plusSeconds(60), now, 1, true)))
+        _ <- xa.run(dml.insert(TestRow(-1, "active", "node-1", now.minusSeconds(60), now, 2, true))) // expired claim
+        _ <- xa.run(dml.insert(TestRow(-1, "active", "node-2", now.plusSeconds(60), now, 3, true)))  // valid claim
+        // Query: active AND (claimedBy = '' OR claimedUntil < now) - find claimable rows
+        results <- xa.run(
+          Query[TestRow]
+            .where(_.active)
+            .eq(true)
+            .andWhere(w => w(_.claimedBy).eq("").or(_.claimedUntil).lt(now))
+            .query[TestRow]
+        )
+        _ <- xa.run(ddl.dropTable[TestRow]())
+      yield assertTrue(results.size == 2) // unclaimed + expired claim
+      end for
+    ,
+    test("Update with andWhere updates correct rows"):
+      val now = Instant.now()
+      for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[TestRow]())
+        // Insert test data
+        _ <- xa.run(
+          dml.insert(TestRow(-1, "pending", "", now, now.plusSeconds(60), 1, true))
+        )
+        _ <- xa.run(
+          dml.insert(TestRow(-1, "pending", "other-node", now.plusSeconds(300), now.plusSeconds(60), 2, true))
+        )
+        // Update only rows with empty claimedBy OR low priority
+        updated <- xa.run(
+          Update[TestRow]
+            .set(_.claimedBy, "my-node")
+            .set(_.priority, 10)
+            .where(_.status)
+            .eq("pending")
+            .andWhere(w => w(_.claimedBy).eq("").or(_.priority).lt(2))
+            .build
+            .update
+        )
+        remaining <- xa.run(Query[TestRow].where(_.claimedBy).eq("").query[TestRow])
+        _         <- xa.run(ddl.dropTable[TestRow]())
+      yield assertTrue(updated == 1) && // Only one row updated (empty claimedBy)
+        assertTrue(remaining.isEmpty)   // The claimable row was claimed
+      end for
+    ,
+    test("Query with IS NULL in andWhere"):
+      val now = Instant.now()
+      val res = for
+        xa <- ZIO.service[Transactor]
+        _  <- xa.run(ddl.createTable[NullableRow]())
+        // Insert test data
+        _ <- xa.run(dml.insert(NullableRow(-1, Some("active"), Some("node-1"), Some(now.plusSeconds(60)), now, true)))
+        _ <- xa.run(dml.insert(NullableRow(-1, None, None, None, now, true)))
+        _ <- xa.run(dml.insert(NullableRow(-1, Some("pending"), None, Some(now.minusSeconds(60)), now, true)))
+        // Query: active AND (status IS NULL OR claimedBy IS NULL)
+        results <- xa.run(
+          Query[NullableRow]
+            .where(_.active)
+            .eq(true)
+            .andWhere(w => w(_.status).isNull.or(_.claimedBy).isNull)
+            .query[NullableRow]
+        )
+        _ <- xa.run(ddl.dropTable[NullableRow]())
+      yield assertTrue(results.size == 2)
+      res,
+    // status=None row and claimedBy=None rows
+  ).provideShared(xaLayer) @@ TestAspect.sequential
+
+  override def spec = suite("WhereGroupSpecs")(
+    sqlGenerationTests,
+    integrationTests,
+  )
+end WhereGroupSpecs


### PR DESCRIPTION
## Summary

Implements P0 and P1 features from the Mechanoid wishlist to enable type-safe DSL migration from raw SQL.

- **Conditional Upsert DSL** (`ON CONFLICT ... WHERE`) - Enables atomic lock acquisition/extension patterns
- **UPDATE ... RETURNING DSL** - Type-safe `returningAs` with capability constraints
- **Complex WHERE with OR/AND grouping** - `andWhere` lambda syntax for parenthesized conditions
- **Aggregate functions** - `max`, `min`, `sum`, `count`, `avg`, `countAll`, `coalesce`

## New Files

- [`core/src/main/scala/saferis/Upsert.scala`](core/src/main/scala/saferis/Upsert.scala) - Full Upsert DSL with builder chain pattern
- [`core/src/main/scala/saferis/Aggregate.scala`](core/src/main/scala/saferis/Aggregate.scala) - Type-safe aggregate function DSL
- [`core/src/main/scala/saferis/WhereGroup.scala`](core/src/main/scala/saferis/WhereGroup.scala) - OR/AND grouping for complex WHERE conditions

## Modified Files

- [`Condition.scala`](core/src/main/scala/saferis/Condition.scala) - Added `ExcludedCondition` for EXCLUDED pseudo-table
- [`Mutation.scala`](core/src/main/scala/saferis/Mutation.scala) - Added `andWhere`, `returningAs` to Update/Delete
- [`Query.scala`](core/src/main/scala/saferis/Query.scala) - Added `andWhere`, `selectAggregate`
- [`DialectCapabilities.scala`](core/src/main/scala/saferis/DialectCapabilities.scala) - Extended `UpsertSupport`
- [`PostgresDialect.scala`](core/src/main/scala/saferis/postgres/PostgresDialect.scala) - Implemented new upsert methods
- [`Dialect.scala`](core/src/main/scala/saferis/Dialect.scala) - Singleton type for capability intersections

## Usage Examples

### Conditional Upsert
```scala
Upsert[Lock]
  .values(Lock(instanceId, nodeId, now, expiresAt))
  .onConflict(_.instanceId)
  .doUpdateAll
  .where(_.expiresAt).lt(now)
  .or(_.nodeId).eqExcluded  // Reference EXCLUDED pseudo-table
  .returning
  .queryOne
```

### Complex WHERE with OR
```scala
Query[TimeoutRow]
  .where(_.deadline).lte(now)
  .andWhere(w => w(_.claimedBy).isNull.or(_.claimedUntil).lt(now))
  .query[TimeoutRow]
// Generates: WHERE deadline <= ? AND (claimed_by IS NULL OR claimed_until < ?)
```

### Aggregates with COALESCE
```scala
Query[EventRow]
  .where(_.instanceId).eq(instanceId)
  .selectAggregate(_.sequenceNr)(_.max.coalesce(0L))
  .queryValue[Long]
```

### Type-safe RETURNING
```scala
Update[Lock]
  .set(_.expiresAt, newExpiry)
  .where(_.instanceId).eq(instanceId)
  .returningAs  // Only compiles with ReturningSupport
  .queryOne
```

## Test plan
- [x] 14 tests for WhereGroup (SQL generation + integration)
- [x] 12 tests for Upsert (SQL generation + integration)
- [x] 13 tests for Aggregates (SQL generation + integration)
- [x] All 382 tests pass
- [x] Documentation updated with new feature sections