### PR TITLE
Support generic Json[E] fields in Table derivation

### DIFF
--- a/core/src/main/scala/saferis/Interpolator.scala
+++ b/core/src/main/scala/saferis/Interpolator.scala
@@ -82,9 +82,10 @@ object Interpolator:
   ): Expr[Vector[Placeholder]] =
     import quotes.reflect.*
 
-    // Helper to check if type is an Instance
+    // Helper to check if type is an Instance (using type symbol comparison for robustness)
+    val instanceTypeSymbol                     = TypeRepr.of[Instance[?]].typeSymbol
     def isInstanceType(tpe: TypeRepr): Boolean =
-      tpe.baseClasses.exists(_.fullName == "saferis.Instance")
+      tpe.baseClasses.contains(instanceTypeSymbol)
 
     all match
       case '{ $arg: Placeholder } +: rest =>


### PR DESCRIPTION
## Summary

- Fixes generic `Json[E]` field handling in `Table.derived` macro
- Adds type parameter substitution to resolve path-dependent types like `GenericRow.this.E`
- Handles opaque type representation differences (`CachedAppliedType`, `$package$.Json` naming)

## Problem

When deriving `Table` for a generic case class with a `Json[E]` field:

```scala
@tableName("events")
case class EventRow[E: JsonCodec](@generated @key id: Long, data: Json[E])

class EventStore[E: JsonCodec](xa: Transactor):
  given Table[EventRow[E]] = Table.derived[EventRow[E]]  // Previously failed!
```

The macro failed with:
```
Could not find a Decoder for saferis.Json$package.Json[GenericRow.this.E]
```

## Solution

1. Build a map from type parameter names to actual type arguments in `columnsOfImpl`
2. When encountering `Json[GenericRow.this.E]`, resolve `E` using the substitution map
3. Use `Implicits.search` to find `JsonCodec[ActualType]` from the calling context

Key technical details:
- Opaque types use `saferis.Json$package$.Json` (extra `$`) vs case classes
- Type representation is `CachedAppliedType` requiring `typeArgs` instead of `AppliedType` pattern matching

## Test plan

- [x] Added integration test for generic `Json[E]` table derivation
- [x] All 383 existing tests pass
- [x] Verified JSON data is correctly inserted and retrieved