### PR TITLE
Fix Query DSL and makeImpl for generic types with context bounds

### DIFF
--- a/core/src/main/scala/saferis/Query.scala
+++ b/core/src/main/scala/saferis/Query.scala
@@ -1582,7 +1582,7 @@ object Query:
     *     .query[UserWithOrder]
     * }}}
     */
-  def apply[A <: Product: Table]: Query1Builder[A] =
+  inline def apply[A <: Product: Table]: Query1Builder[A] =
     val gen      = AliasGenerator.create()
     val instance = gen.aliasedInstance[A]
     Query1Builder(gen, instance)


### PR DESCRIPTION
## Summary

- **Query.apply now inline**: Implicit resolution happens at call site, enabling polymorphic givens from companion objects to be found
- **makeImpl handles generic case classes**: The macro now correctly constructs instances of generic case classes with context bounds like `case class Foo[E: JsonCodec](...)`

## Problem

When using the Query DSL with generic table types that have polymorphic givens in their companion objects:

```scala
case class QueryEventRow[E: JsonCodec](@generated @key id: Long, data: Json[E])
object QueryEventRow:
  given [E: JsonCodec]: Table[QueryEventRow[E]] = Table.derived
```

The `Query[QueryEventRow[E]]` call would fail because:
1. `Query.apply` was not `inline`, so implicit resolution happened in the Query object scope
2. `makeImpl` didn't handle the `apply` method's type arguments and using clauses

## Solution

1. Made `Query.apply` inline so implicit resolution happens at the call site ([Query.scala:1585](core/src/main/scala/saferis/Query.scala#L1585))

2. Updated `makeImpl` to handle generic case classes with context bounds ([Macros.scala:363-416](core/src/main/scala/saferis/Macros.scala#L363-L416)):
   - Applies type arguments using `TypeApply`
   - Detects using clauses by checking `Given`/`Implicit` flags
   - Searches for and provides the required context bound implicits

## Test plan

- [x] All 384 existing tests pass
- [x] New test verifies Query DSL works with polymorphic givens from companion objects
- [x] Test demonstrates the recommended pattern for generic `Json[E]` tables