### PR TITLE
Fix Schema DSL to respect @label annotation

### DIFF
--- a/core/src/main/scala/saferis/DataDefinitionLayer.scala
+++ b/core/src/main/scala/saferis/DataDefinitionLayer.scala
@@ -109,14 +109,15 @@ object DataDefinitionLayer:
 
     // Create indexes from Schema-defined IndexSpecs
     val aspectIndexes = instance.indexes.map { spec =>
-      val createSql = spec.toCreateSql(tableName)
-      val sql       = dialect match
+      val columnLabels = spec.columns.map(instance.fieldToLabel)
+      val createSql    = spec.toCreateSql(tableName, instance.fieldToLabel)
+      val sql          = dialect match
         case d: IndexIfNotExistsSupport =>
-          val indexName = spec.name.getOrElse(s"idx_${tableName}_${spec.columns.mkString("_")}")
+          val indexName = spec.name.getOrElse(s"idx_${tableName}_${columnLabels.mkString("_")}")
           SqlFragment(
             if spec.unique then
-              d.createIndexIfNotExistsSql(indexName, tableName, spec.columns, unique = true, where = spec.where)
-            else d.createIndexIfNotExistsSql(indexName, tableName, spec.columns, unique = false, where = spec.where),
+              d.createIndexIfNotExistsSql(indexName, tableName, columnLabels, unique = true, where = spec.where)
+            else d.createIndexIfNotExistsSql(indexName, tableName, columnLabels, unique = false, where = spec.where),
             Seq.empty,
           )
         case _ => SqlFragment(createSql, Seq.empty)

--- a/core/src/main/scala/saferis/ForeignKey.scala
+++ b/core/src/main/scala/saferis/ForeignKey.scala
@@ -20,11 +20,13 @@ end ForeignKeyAction
   * @tparam To
   *   The referenced table type
   * @param fromColumns
-  *   Column name(s) in the source table
+  *   Column field names in the source table (will be converted to labels at SQL generation time)
   * @param toTable
   *   Name of the referenced table
   * @param toColumns
-  *   Column name(s) in the referenced table
+  *   Column field names in the referenced table (will be converted to labels at SQL generation time)
+  * @param toColumnMap
+  *   Column map from target table for field name to label conversion
   * @param onDelete
   *   Action to take when referenced row is deleted
   * @param onUpdate
@@ -36,16 +38,23 @@ final case class ForeignKeySpec[From <: Product, To <: Product](
     fromColumns: Seq[String],
     toTable: String,
     toColumns: Seq[String],
+    toColumnMap: Map[String, Column[?]] = Map.empty,
     onDelete: ForeignKeyAction = ForeignKeyAction.NoAction,
     onUpdate: ForeignKeyAction = ForeignKeyAction.NoAction,
     constraintName: Option[String] = None,
 ):
-  /** Generates the SQL FOREIGN KEY constraint clause */
-  def toConstraintSql: String =
+  /** Generates the SQL FOREIGN KEY constraint clause
+    *
+    * @param fromFieldToLabel
+    *   Function to convert source table field names to column labels (respects @label annotations)
+    */
+  def toConstraintSql(fromFieldToLabel: String => String): String =
     val constraintClause = constraintName.fold("")(n => s"constraint $n ")
-    val fromColsSql      = fromColumns.mkString(", ")
-    val toColsSql        = toColumns.mkString(", ")
-    val onDeleteClause   = if onDelete == ForeignKeyAction.NoAction then "" else s" on delete ${onDelete.toSql}"
-    val onUpdateClause   = if onUpdate == ForeignKeyAction.NoAction then "" else s" on update ${onUpdate.toSql}"
+    val fromColsSql      = fromColumns.map(fromFieldToLabel).mkString(", ")
+    // Use toColumnMap if available, otherwise use field name directly
+    val toFieldToLabel: String => String = fn => toColumnMap.get(fn).map(_.label).getOrElse(fn)
+    val toColsSql                        = toColumns.map(toFieldToLabel).mkString(", ")
+    val onDeleteClause = if onDelete == ForeignKeyAction.NoAction then "" else s" on delete ${onDelete.toSql}"
+    val onUpdateClause = if onUpdate == ForeignKeyAction.NoAction then "" else s" on update ${onUpdate.toSql}"
     s"${constraintClause}foreign key ($fromColsSql) references $toTable ($toColsSql)$onDeleteClause$onUpdateClause"
 end ForeignKeySpec

--- a/core/src/main/scala/saferis/UniqueConstraint.scala
+++ b/core/src/main/scala/saferis/UniqueConstraint.scala
@@ -5,7 +5,7 @@ package saferis
   * @tparam A
   *   The table type this constraint belongs to
   * @param columns
-  *   Column name(s) for the unique constraint
+  *   Column field names for the unique constraint (will be converted to labels at SQL generation time)
   * @param constraintName
   *   Optional custom constraint name (auto-generated if None)
   */
@@ -13,8 +13,13 @@ final case class UniqueConstraintSpec[A <: Product](
     columns: Seq[String],
     constraintName: Option[String] = None,
 ):
-  /** Generate UNIQUE constraint SQL for this spec */
-  def toConstraintSql: String =
-    val name = constraintName.getOrElse(s"uq_${columns.mkString("_")}")
-    s"constraint $name unique (${columns.mkString(", ")})"
+  /** Generate UNIQUE constraint SQL for this spec
+    *
+    * @param fieldToLabel
+    *   Function to convert field names to column labels (respects @label annotations)
+    */
+  def toConstraintSql(fieldToLabel: String => String): String =
+    val columnLabels = columns.map(fieldToLabel)
+    val name         = constraintName.getOrElse(s"uq_${columnLabels.mkString("_")}")
+    s"constraint $name unique (${columnLabels.mkString(", ")})"
 end UniqueConstraintSpec


### PR DESCRIPTION
## Summary

- Fixed Schema DSL (DDL generation) to respect `@label` annotations when generating SQL
- Previously, column names in indexes, unique constraints, foreign keys, and partial index WHERE clauses used Scala field names instead of labeled column names
- Example: `@label("instance_id") instanceId: String` generated `instanceid` instead of `instance_id`

## Changes

| File | Change |
|------|--------|
| [Index.scala](core/src/main/scala/saferis/Index.scala) | `toCreateSql` accepts `fieldToLabel` parameter |
| [UniqueConstraint.scala](core/src/main/scala/saferis/UniqueConstraint.scala) | `toConstraintSql` accepts `fieldToLabel` parameter |
| [ForeignKey.scala](core/src/main/scala/saferis/ForeignKey.scala) | Added `toColumnMap` for target table label lookup |
| [Instance.scala](core/src/main/scala/saferis/Instance.scala) | Added `fieldToLabel: Map[String, String]` |
| [Schema.scala](core/src/main/scala/saferis/Schema.scala) | WHERE builders use `instance.fieldToLabel` |
| [DataDefinitionLayer.scala](core/src/main/scala/saferis/DataDefinitionLayer.scala) | Index creation uses `instance.fieldToLabel` |

## Test plan

- [x] Added 8 new tests in SchemaSpecs.scala covering:
  - Single and compound index with `@label`
  - Partial index WHERE clause with `@label`
  - Single and compound unique constraint with `@label`
  - Foreign key source and target columns with `@label`
  - Grouped WHERE conditions with `@label`
- [x] All 71 SchemaSpecs tests pass
- [x] All 392 project tests pass