### PR TITLE
Add IN literal collection helpers with deferred validation issues

### DIFF
--- a/core/src/main/scala/saferis/FragmentIssue.scala
+++ b/core/src/main/scala/saferis/FragmentIssue.scala
@@ -1,0 +1,32 @@
+package saferis
+
+/** Represents a problem detected at SQL-fragment construction time that should fail the statement before any JDBC call
+  * is made.
+  *
+  * Issues are accumulated on `Placeholder` and `SqlFragment` and surface as [[SaferisError.InvalidStatement]] when the
+  * fragment is run. This keeps fragment construction pure (no thrown exceptions) while still surfacing failures through
+  * the library's typed-error channel.
+  */
+sealed trait FragmentIssue:
+  def description: String
+
+object FragmentIssue:
+
+  /** An IN/NOT-IN/list helper was called with an empty (or degenerate-empty-after-dedupe) collection. The resulting SQL
+    * would be invalid (`IN ()` / empty placeholder list).
+    *
+    * @param helper
+    *   Name of the helper that produced the issue (e.g. "in", "Placeholder.list", "WhereBuilder.in"). Used in the error
+    *   message so the user can locate the offending call.
+    * @param origin
+    *   Stack frame captured at construction, pointing at the user's call site. Surfaces in the error message even
+    *   though the failure is reported at execution time.
+    */
+  final case class EmptyCollection(
+      helper: String,
+      origin: Option[StackTraceElement],
+  ) extends FragmentIssue:
+    def description: String =
+      val site = origin.fold("")(o => s" at $o")
+      s"$helper requires a non-empty collection$site; guard the call site with `if coll.isEmpty then ...`"
+end FragmentIssue

--- a/core/src/main/scala/saferis/Interpolator.scala
+++ b/core/src/main/scala/saferis/Interpolator.scala
@@ -9,8 +9,43 @@ class silent extends Annotation
 
 export Interpolator.sql
 export Interpolator.sqlEcho
+export Interpolator.in
 
 object Interpolator:
+
+  /** Splice a collection of values as `(?, ?, ?, ...)` for an IN clause:
+    *
+    * {{{
+    *   sql"select * from $table where ${table.id} in ${in(ids)}"
+    * }}}
+    *
+    * Accepts any `Iterable[A]` (`Seq`, `List`, `Set`, `LinkedHashSet`, etc.). Duplicates are removed before placeholder
+    * construction. Each remaining element binds one parameter via the implicit `Encoder[A]`.
+    *
+    * On empty (or degenerate-empty-after-dedupe) input, the resulting placeholder carries a
+    * [[FragmentIssue.EmptyCollection]] that surfaces as [[SaferisError.InvalidStatement]] at execution. No DB
+    * round-trip on failure.
+    */
+  def in[A](values: Iterable[A])(using Encoder[A]): Placeholder =
+    Placeholder.concat(
+      Placeholder.raw("("),
+      Placeholder.listTagged(values, helper = "in", origin = Placeholder.captureOrigin()),
+      Placeholder.raw(")"),
+    )
+
+  /** Varargs convenience overload — at least one element by construction.
+    *
+    * {{{
+    *   sql"... where ${table.status} in ${in("active", "pending")}"
+    * }}}
+    */
+  def in[A](first: A, rest: A*)(using Encoder[A]): Placeholder =
+    Placeholder.concat(
+      Placeholder.raw("("),
+      Placeholder.listTagged(first +: rest, helper = "in", origin = Placeholder.captureOrigin()),
+      Placeholder.raw(")"),
+    )
+
   extension (inline sc: StringContext)
     /** Interpolates a string context creating an [[SqlFragment]].
       *
@@ -64,9 +99,10 @@ object Interpolator:
     val holder     = '{ (Vector.newBuilder[Placeholder]) }
     val placeExprs = getPlaceHoldersExpr(allArgsExprs, holder)
     val writeExprs = '{ Placeholder.allWrites($placeExprs) }
+    val issueExprs = '{ Placeholder.allIssues($placeExprs) }
     val query      = '{ $sc.s($placeExprs.map(_.sql)*) }
     val res        = '{
-      SqlFragment($query, $writeExprs)
+      SqlFragment($query, $writeExprs, $issueExprs)
     }
     res
 

--- a/core/src/main/scala/saferis/Mutation.scala
+++ b/core/src/main/scala/saferis/Mutation.scala
@@ -198,7 +198,11 @@ final case class UpdateReady[A <: Product: Table](
 
     if wherePredicates.nonEmpty then
       val whereJoined = Placeholder.join(wherePredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(whereJoined.sql, whereJoined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(
+        whereJoined.sql,
+        whereJoined.writes,
+        whereJoined.issues,
+      )
 
     result
   end build
@@ -360,9 +364,14 @@ final case class DeleteReady[A <: Product: Table](
 
     if wherePredicates.nonEmpty then
       val whereJoined = Placeholder.join(wherePredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(whereJoined.sql, whereJoined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(
+        whereJoined.sql,
+        whereJoined.writes,
+        whereJoined.issues,
+      )
 
     result
+  end build
 
   /** Build DELETE with RETURNING clause (for dialects that support it) */
   def returning: SqlFragment =

--- a/core/src/main/scala/saferis/Placeholder.scala
+++ b/core/src/main/scala/saferis/Placeholder.scala
@@ -7,9 +7,15 @@ trait Placeholder:
   private[saferis] def writes: Seq[Write[?]]
   def sql: String
 
+  /** Validation issues accumulated during fragment construction. Empty for normal placeholders; non-empty when a helper
+    * (e.g. an empty IN-list) couldn't produce valid SQL. Surfaces as [[SaferisError.InvalidStatement]] at execution.
+    */
+  private[saferis] def issues: List[FragmentIssue] = Nil
+
   /** Combine this placeholder with another placeholder */
   final def ++(other: Placeholder): Placeholder =
-    Placeholder.Derived(writes ++ other.writes, sql + other.sql)
+    Placeholder.Derived(writes ++ other.writes, sql + other.sql, issues ++ other.issues)
+end Placeholder
 
 object Placeholder:
   /** Create a placeholder from a value with an encoder */
@@ -36,7 +42,11 @@ object Placeholder:
 
   /** Create a placeholder from multiple placeholders */
   def concat(placeholders: Placeholder*): Placeholder =
-    Derived(placeholders.flatMap(_.writes), placeholders.map(_.sql).mkString)
+    Derived(
+      placeholders.flatMap(_.writes),
+      placeholders.map(_.sql).mkString,
+      placeholders.toList.flatMap(_.issues),
+    )
 
   /** Create a placeholder with a separator between elements */
   def join(placeholders: Seq[Placeholder], separator: String = ", "): Placeholder =
@@ -45,16 +55,62 @@ object Placeholder:
     else
       val sql    = placeholders.map(_.sql).mkString(separator)
       val writes = placeholders.flatMap(_.writes)
-      Derived(writes, sql)
+      val issues = placeholders.toList.flatMap(_.issues)
+      Derived(writes, sql, issues)
 
   /** Create a comma-separated list of placeholders */
   def commaList(placeholders: Placeholder*): Placeholder =
     join(placeholders, ", ")
 
+  /** Splice a collection of values as a comma-separated list of parameterized placeholders.
+    *
+    * Accepts any `Iterable[A]` (`Seq`, `List`, `Set`, `LinkedHashSet`, etc.). Duplicates are removed (set semantics;
+    * matches typical IN-clause use). Each remaining element becomes one `?` bound via the implicit `Encoder[A]`. Useful
+    * for VALUES rows and other comma-separated list contexts. For IN clauses prefer the top-level `in` helper, which
+    * adds the surrounding parentheses.
+    *
+    * Order: follows the input iterator's order, preserving insertion order for ordered collections.
+    *
+    * On empty (or degenerate-empty-after-dedupe) input, returns a placeholder carrying a
+    * [[FragmentIssue.EmptyCollection]]. The issue surfaces as [[SaferisError.InvalidStatement]] when the resulting
+    * fragment is run — no throw at the call site.
+    */
+  def list[A](values: Iterable[A])(using Encoder[A]): Placeholder =
+    listTagged(values, helper = "Placeholder.list", origin = captureOrigin())
+
+  /** Varargs convenience overload — at least one element by construction. */
+  def list[A](first: A, rest: A*)(using Encoder[A]): Placeholder =
+    listTagged(first +: rest, helper = "Placeholder.list", origin = captureOrigin())
+
+  /** Internal helper used by `list` and `Interpolator.in` so each can tag the issue with the helper name the user
+    * actually called and pass an origin captured at the user-facing entry point.
+    */
+  private[saferis] def listTagged[A](values: Iterable[A], helper: String, origin: Option[StackTraceElement])(using
+      sw: Encoder[A]
+  ): Placeholder =
+    val deduped = values.iterator.distinct.toVector
+    if deduped.isEmpty then
+      Derived(writes = Nil, sql = "", issues = List(FragmentIssue.EmptyCollection(helper, origin)))
+    else join(deduped.map(Placeholder.apply[A]), ", ")
+
+  /** Capture the user's call-site frame. Walks the stack trace and returns the first frame whose declaring class is
+    * outside the `saferis` package, ignoring synthetic frames introduced by `export` aliases or inlined helpers.
+    */
+  private[saferis] def captureOrigin(): Option[StackTraceElement] =
+    val st = new Throwable().getStackTrace
+    st.find(f => !f.getClassName.startsWith("saferis."))
+
   /** Extract all writes from a sequence of placeholders */
   def allWrites(ps: Seq[Placeholder]): Seq[Write[?]] = ps.flatMap(_.writes)
 
-  final private case class Derived(override private[saferis] val writes: Seq[Write[?]], sql: String) extends Placeholder
+  /** Extract all validation issues from a sequence of placeholders */
+  private[saferis] def allIssues(ps: Seq[Placeholder]): List[FragmentIssue] = ps.toList.flatMap(_.issues)
+
+  final private case class Derived(
+      override private[saferis] val writes: Seq[Write[?]],
+      sql: String,
+      override private[saferis] val issues: List[FragmentIssue] = Nil,
+  ) extends Placeholder
 
   given convertToPlaceholder[A](using sw: Encoder[A]): Conversion[A, Placeholder] with
     def apply(a: A): Placeholder =
@@ -64,7 +120,8 @@ object Placeholder:
     def apply(as: Seq[Placeholder]): Placeholder =
       val sql    = as.map(_.sql).mkString("")
       val writes = as.flatMap(_.writes)
-      Derived(writes, sql)
+      val issues = as.toList.flatMap(_.issues)
+      Derived(writes, sql, issues)
 
   /** A raw SQL query fragment. This should be used cautiously, as it if misused it could open up the possibility of SQL
     * injection attacks. Only use this when you are sure that the SQL fragment is safe - not derived from user input for

--- a/core/src/main/scala/saferis/Query.scala
+++ b/core/src/main/scala/saferis/Query.scala
@@ -78,10 +78,10 @@ trait QueryBase:
   *   val subquery: SelectQuery[Int] = Query[Order].select(_.userId)
   *
   *   // IN requires matching types - this compiles because _.id is Int
-  *   Query[User].where(_.id).in(subquery)
+  *   Query[User].where(_.id).inSubquery(subquery)
   *
   *   // This would NOT compile: _.name is String, subquery returns Int
-  *   // Query[User].where(_.name).in(subquery)
+  *   // Query[User].where(_.name).inSubquery(subquery)
   * }}}
   */
 final case class SelectQuery[T](query: QueryBase) extends QueryBase:
@@ -404,7 +404,7 @@ final case class Query1Ready[A <: Product: Table](
     val allPredicates  = (wherePredicates ++ seekPredicates).filter(_.sql.trim.nonEmpty)
     if allPredicates.nonEmpty then
       val joined = Placeholder.join(allPredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     // ORDER BY clause (explicit sorts + seek sorts)
     val seekSorts = seeks.map(_.toSort)
@@ -412,7 +412,7 @@ final case class Query1Ready[A <: Product: Table](
     if allSorts.nonEmpty then
       val sortFragments = allSorts.map(_.toSqlFragment)
       val joined        = Placeholder.join(sortFragments, ", ")
-      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     // LIMIT/OFFSET
     limitValue.foreach(n => result = result :+ SqlFragment(s" limit $n", Seq.empty))
@@ -876,7 +876,7 @@ final case class Query2Ready[A <: Product: Table, B <: Product: Table](
     val allPredicates  = (wherePredicates ++ seekPredicates).filter(_.sql.trim.nonEmpty)
     if allPredicates.nonEmpty then
       val joined = Placeholder.join(allPredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     // ORDER BY clause
     val seekSorts = seeks.map(_.toSort)
@@ -884,7 +884,7 @@ final case class Query2Ready[A <: Product: Table, B <: Product: Table](
     if allSorts.nonEmpty then
       val sortFragments = allSorts.map(_.toSqlFragment)
       val joined        = Placeholder.join(sortFragments, ", ")
-      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     // LIMIT/OFFSET
     limitValue.foreach(n => result = result :+ SqlFragment(s" limit $n", Seq.empty))
@@ -1163,14 +1163,14 @@ final case class Query3Ready[A <: Product: Table, B <: Product: Table, C <: Prod
     val allPredicates  = (wherePredicates ++ seekPredicates).filter(_.sql.trim.nonEmpty)
     if allPredicates.nonEmpty then
       val joined = Placeholder.join(allPredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     val seekSorts = seeks.map(_.toSort)
     val allSorts  = sorts ++ seekSorts
     if allSorts.nonEmpty then
       val sortFragments = allSorts.map(_.toSqlFragment)
       val joined        = Placeholder.join(sortFragments, ", ")
-      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     limitValue.foreach(n => result = result :+ SqlFragment(s" limit $n", Seq.empty))
     offsetValue.foreach(n => result = result :+ SqlFragment(s" offset $n", Seq.empty))
@@ -1365,14 +1365,14 @@ final case class Query4Ready[A <: Product: Table, B <: Product: Table, C <: Prod
     val allPredicates  = (wherePredicates ++ seekPredicates).filter(_.sql.trim.nonEmpty)
     if allPredicates.nonEmpty then
       val joined = Placeholder.join(allPredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     val seekSorts = seeks.map(_.toSort)
     val allSorts  = sorts ++ seekSorts
     if allSorts.nonEmpty then
       val sortFragments = allSorts.map(_.toSqlFragment)
       val joined        = Placeholder.join(sortFragments, ", ")
-      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     limitValue.foreach(n => result = result :+ SqlFragment(s" limit $n", Seq.empty))
     offsetValue.foreach(n => result = result :+ SqlFragment(s" offset $n", Seq.empty))
@@ -1603,14 +1603,14 @@ final case class Query5Ready[
     val allPredicates  = (wherePredicates ++ seekPredicates).filter(_.sql.trim.nonEmpty)
     if allPredicates.nonEmpty then
       val joined = Placeholder.join(allPredicates, " and ")
-      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" where ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     val seekSorts = seeks.map(_.toSort)
     val allSorts  = sorts ++ seekSorts
     if allSorts.nonEmpty then
       val sortFragments = allSorts.map(_.toSqlFragment)
       val joined        = Placeholder.join(sortFragments, ", ")
-      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes)
+      result = result :+ SqlFragment(" order by ", Seq.empty) :+ SqlFragment(joined.sql, joined.writes, joined.issues)
 
     limitValue.foreach(n => result = result :+ SqlFragment(s" limit $n", Seq.empty))
     offsetValue.foreach(n => result = result :+ SqlFragment(s" offset $n", Seq.empty))

--- a/core/src/main/scala/saferis/SaferisError.scala
+++ b/core/src/main/scala/saferis/SaferisError.scala
@@ -98,6 +98,18 @@ object SaferisError:
       val summary = if count == 1 then "1 issue" else s"$count issues"
       s"Schema validation failed with $summary:\n${issues.map(i => s"  - ${i.description}").mkString("\n")}"
 
+  // === Statement Construction ===
+
+  /** A statement could not be sent to JDBC because one or more validation issues were detected during fragment
+    * construction (e.g. an empty `IN ()` list). The fragment carries the issues from the offending helper(s); execution
+    * refuses to acquire a connection and fails with this error instead.
+    */
+  final case class InvalidStatement(issues: List[FragmentIssue]) extends SaferisError:
+    def message =
+      val count   = issues.length
+      val summary = if count == 1 then "1 issue" else s"$count issues"
+      s"Statement construction failed with $summary:\n${issues.map(i => s"  - ${i.description}").mkString("\n")}"
+
   // === Unexpected (for truly unexpected non-SQL errors) ===
 
   final case class Unexpected(cause: Throwable) extends SaferisError:

--- a/core/src/main/scala/saferis/SqlFragment.scala
+++ b/core/src/main/scala/saferis/SqlFragment.scala
@@ -11,6 +11,7 @@ type ScopedQuery[E] = ZIO[ConnectionProvider & Scope, SaferisError, E]
 final case class SqlFragment(
     sql: String,
     override private[saferis] val writes: Seq[Write[?]],
+    override private[saferis] val issues: List[FragmentIssue] = Nil,
 ) extends Placeholder:
 
   inline private def make[E <: Product](rs: ResultSet)(using table: Table[E])(using trace: Trace): Task[E] =
@@ -45,26 +46,46 @@ final case class SqlFragment(
         .serviceWith[ConnectionProvider](_.retryClassifier)
         .map(SaferisError.fromThrowable(t, Some(sqlText), _))
 
+  /** Refuse to run if the fragment carries validation issues. The check happens before any connection is acquired, so
+    * invalid fragments never reach JDBC.
+    */
+  private def validateIssues[R, A](effect: => ZIO[R, SaferisError, A])(using
+      trace: Trace
+  ): ZIO[R, SaferisError, A] =
+    if issues.isEmpty then effect
+    else ZIO.fail(SaferisError.InvalidStatement(issues))
+
+  /** Lift this fragment's validation status into a ZIO effect.
+    *
+    * Succeeds with the fragment if no issues were accumulated during construction; fails with
+    * [[SaferisError.InvalidStatement]] otherwise. Useful for callers who want to surface or log construction failures
+    * before running the statement.
+    */
+  def validate(using trace: Trace): IO[SaferisError, SqlFragment] =
+    if issues.isEmpty then ZIO.succeed(this)
+    else ZIO.fail(SaferisError.InvalidStatement(issues))
+
   /** Executes a query and returns an effect of a Chunk of [[Table]] instances.
     *
     * @return
     */
   inline def query[E <: Product: Table](using trace: Trace): ScopedQuery[Chunk[E]] =
-    val effect = for
-      connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
-      statement  <- ZIO.attempt(connection.prepareStatement(sql))
-      _          <- applyTimeout(statement)
-      _          <- doWrites(statement)
-      rs         <- ZIO.attempt(statement.executeQuery())
-      results    <-
-        def loop(acc: ChunkBuilder[E]): ZIO[Any, Throwable, Chunk[E]] =
-          ZIO.attempt(rs.next()).flatMap { hasNext =>
-            if hasNext then make[E](rs).flatMap(e => loop(acc += e))
-            else ZIO.succeed(acc.result())
-          }
-        loop(Chunk.newBuilder[E])
-    yield results
-    classifyError(effect, sql)
+    validateIssues:
+      val effect = for
+        connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
+        statement  <- ZIO.attempt(connection.prepareStatement(sql))
+        _          <- applyTimeout(statement)
+        _          <- doWrites(statement)
+        rs         <- ZIO.attempt(statement.executeQuery())
+        results    <-
+          def loop(acc: ChunkBuilder[E]): ZIO[Any, Throwable, Chunk[E]] =
+            ZIO.attempt(rs.next()).flatMap { hasNext =>
+              if hasNext then make[E](rs).flatMap(e => loop(acc += e))
+              else ZIO.succeed(acc.result())
+            }
+          loop(Chunk.newBuilder[E])
+      yield results
+      classifyError(effect, sql)
   end query
 
   /** Executes a query and returns an effect of an option of [[Table]]. If the query returns no rows, None is returned.
@@ -72,15 +93,16 @@ final case class SqlFragment(
     * @return
     */
   inline def queryOne[E <: Product: Table](using trace: Trace): ScopedQuery[Option[E]] =
-    val effect = for
-      connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
-      statement  <- ZIO.attempt(connection.prepareStatement(sql))
-      _          <- applyTimeout(statement)
-      _          <- doWrites(statement)
-      rs         <- ZIO.attempt(statement.executeQuery())
-      result     <- if rs.next() then make[E](rs).map(Some(_)) else ZIO.succeed(None)
-    yield result
-    classifyError(effect, sql)
+    validateIssues:
+      val effect = for
+        connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
+        statement  <- ZIO.attempt(connection.prepareStatement(sql))
+        _          <- applyTimeout(statement)
+        _          <- doWrites(statement)
+        rs         <- ZIO.attempt(statement.executeQuery())
+        result     <- if rs.next() then make[E](rs).map(Some(_)) else ZIO.succeed(None)
+      yield result
+      classifyError(effect, sql)
   end queryOne
 
   /** Executes a query and returns an effect of a simple value (like Int, String, etc.) from the first column of the
@@ -93,20 +115,21 @@ final case class SqlFragment(
     *   an effect of Option[A] - None if no results, Some(value) if results found
     */
   inline def queryValue[A](using decoder: Decoder[A])(using trace: Trace): ScopedQuery[Option[A]] =
-    val effect = for
-      connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
-      statement  <- ZIO.attempt(connection.prepareStatement(sql))
-      _          <- applyTimeout(statement)
-      _          <- doWrites(statement)
-      rs         <- ZIO.attempt(statement.executeQuery())
-      result     <-
-        if rs.next() then
-          // we need to get the first column and it's name
-          val name = rs.getMetaData.getColumnName(1)
-          decoder.decode(rs, name).map(Some(_))
-        else ZIO.succeed(None)
-    yield result
-    classifyError(effect, sql)
+    validateIssues:
+      val effect = for
+        connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
+        statement  <- ZIO.attempt(connection.prepareStatement(sql))
+        _          <- applyTimeout(statement)
+        _          <- doWrites(statement)
+        rs         <- ZIO.attempt(statement.executeQuery())
+        result     <-
+          if rs.next() then
+            // we need to get the first column and it's name
+            val name = rs.getMetaData.getColumnName(1)
+            decoder.decode(rs, name).map(Some(_))
+          else ZIO.succeed(None)
+      yield result
+      classifyError(effect, sql)
   end queryValue
 
   /** Executes a query and returns a lazy ZStream of [[Table]] instances.
@@ -120,34 +143,38 @@ final case class SqlFragment(
   inline def queryStream[E <: Product: Table](using
       trace: Trace
   ): ZStream[ConnectionProvider & Scope, SaferisError, E] =
-    val thisSql    = sql
-    val acquireRaw =
-      for
-        connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
-        statement  <- ZIO.acquireRelease(ZIO.attempt(connection.prepareStatement(thisSql)))(s => ZIO.succeed(s.close()))
-        _          <- applyTimeout(statement)
-        _          <- doWrites(statement)
-        rs         <- ZIO.acquireRelease(ZIO.attempt(statement.executeQuery()))(r => ZIO.succeed(r.close()))
-      yield rs
-    val acquire: ZIO[ConnectionProvider & Scope, SaferisError, ResultSet] =
-      classifyError(acquireRaw, thisSql)
+    if issues.nonEmpty then ZStream.fail(SaferisError.InvalidStatement(issues))
+    else
+      val thisSql    = sql
+      val acquireRaw =
+        for
+          connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
+          statement  <- ZIO.acquireRelease(ZIO.attempt(connection.prepareStatement(thisSql)))(s =>
+            ZIO.succeed(s.close())
+          )
+          _  <- applyTimeout(statement)
+          _  <- doWrites(statement)
+          rs <- ZIO.acquireRelease(ZIO.attempt(statement.executeQuery()))(r => ZIO.succeed(r.close()))
+        yield rs
+      val acquire: ZIO[ConnectionProvider & Scope, SaferisError, ResultSet] =
+        classifyError(acquireRaw, thisSql)
 
-    def iterate(rs: ResultSet, classifier: SaferisError.RetryClassifier): ZStream[Any, SaferisError, E] =
-      ZStream
-        .unfoldZIO(rs): resultSet =>
-          ZIO
-            .attempt(resultSet.next())
-            .flatMap: hasNext =>
-              if hasNext then make[E](resultSet).map(e => Some((e, resultSet)))
-              else ZIO.succeed(None)
-        .mapError(SaferisError.fromThrowable(_, Some(thisSql), classifier))
+      def iterate(rs: ResultSet, classifier: SaferisError.RetryClassifier): ZStream[Any, SaferisError, E] =
+        ZStream
+          .unfoldZIO(rs): resultSet =>
+            ZIO
+              .attempt(resultSet.next())
+              .flatMap: hasNext =>
+                if hasNext then make[E](resultSet).map(e => Some((e, resultSet)))
+                else ZIO.succeed(None)
+          .mapError(SaferisError.fromThrowable(_, Some(thisSql), classifier))
 
-    val streamed: ZIO[ConnectionProvider & Scope, SaferisError, ZStream[Any, SaferisError, E]] =
-      for
-        rs         <- acquire
-        classifier <- ZIO.serviceWith[ConnectionProvider](_.retryClassifier)
-      yield iterate(rs, classifier)
-    ZStream.unwrapScoped[ConnectionProvider & Scope](streamed)
+      val streamed: ZIO[ConnectionProvider & Scope, SaferisError, ZStream[Any, SaferisError, E]] =
+        for
+          rs         <- acquire
+          classifier <- ZIO.serviceWith[ConnectionProvider](_.retryClassifier)
+        yield iterate(rs, classifier)
+      ZStream.unwrapScoped[ConnectionProvider & Scope](streamed)
   end queryStream
 
   /** alias for [[Statement.dml]]
@@ -179,15 +206,16 @@ final case class SqlFragment(
     * @return
     */
   inline def dml(using trace: Trace): ZIO[ConnectionProvider & Scope, SaferisError, Int] =
-    val effect = for
-      connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
-      statement  <- ZIO.attempt(connection.prepareStatement(sql))
-      _          <- applyTimeout(statement)
-      _          <- ZIO.foreach(writes.zipWithIndex): (write, idx) =>
-        write.write(statement, idx + 1)
-      result <- ZIO.attempt(statement.executeUpdate())
-    yield result
-    classifyError(effect, sql)
+    validateIssues:
+      val effect = for
+        connection <- ZIO.serviceWithZIO[ConnectionProvider](_.getConnection)
+        statement  <- ZIO.attempt(connection.prepareStatement(sql))
+        _          <- applyTimeout(statement)
+        _          <- ZIO.foreach(writes.zipWithIndex): (write, idx) =>
+          write.write(statement, idx + 1)
+        result <- ZIO.attempt(statement.executeUpdate())
+      yield result
+      classifyError(effect, sql)
   end dml
 
   /** Strips leading whitespace from each line in the SQL string, and removes the margin character. See
@@ -210,7 +238,8 @@ final case class SqlFragment(
     * @param other
     * @return
     */
-  def append(other: SqlFragment) = copy(sql = sql + other.sql, writes = writes ++ other.writes)
+  def append(other: SqlFragment) =
+    copy(sql = sql + other.sql, writes = writes ++ other.writes, issues = issues ++ other.issues)
 
   /** alias for [[append]]
     *

--- a/core/src/main/scala/saferis/WhereBuilderOps.scala
+++ b/core/src/main/scala/saferis/WhereBuilderOps.scala
@@ -75,18 +75,65 @@ trait WhereBuilderOps[Parent, T]:
   /** IN subquery - check if value is in the results of another query.
     *
     * Type-safe: the subquery must return the same type T as this column.
+    *
+    * {{{
+    *   val activeIds = Query[Order].where(_.status).eq("active").select(_.userId)
+    *   Query[User].where(_.id).inSubquery(activeIds)
+    * }}}
     */
-  def in(subquery: SelectQuery[T]): Parent =
+  def inSubquery(subquery: SelectQuery[T]): Parent =
     val subquerySql = subquery.build
     val inSql       = s"${whereAlias.toSql}.${whereColumn.label} IN (${subquerySql.sql})"
     val whereFrag   = SqlFragment(inSql, subquerySql.writes)
     addPredicate(whereFrag)
 
   /** NOT IN subquery - type-safe variant */
-  def notIn(subquery: SelectQuery[T]): Parent =
+  def notInSubquery(subquery: SelectQuery[T]): Parent =
     val subquerySql = subquery.build
     val notInSql    = s"${whereAlias.toSql}.${whereColumn.label} NOT IN (${subquerySql.sql})"
     val whereFrag   = SqlFragment(notInSql, subquerySql.writes)
+    addPredicate(whereFrag)
+
+  // === Literal collection operators ===
+
+  /** IN literal — varargs form for inline values. Emits `col IN (?, ?, ?, ...)` with one bound parameter per distinct
+    * element. By construction at least one element is supplied, so this overload always produces valid SQL.
+    *
+    * {{{
+    *   Query[User].where(_.status).in("active", "pending")
+    * }}}
+    *
+    * For runtime collections use [[inList]] instead. For subqueries use [[inSubquery]].
+    */
+  def in(first: T, rest: T*)(using Encoder[T]): Parent =
+    inList(first +: rest)
+
+  /** IN literal collection — accepts any `Iterable[T]` (`Seq`, `List`, `Set`, `LinkedHashSet`, etc.). Duplicates are
+    * removed (set semantics). Emits `col IN (?, ?, ?, ...)`.
+    *
+    * On empty (or degenerate-empty-after-dedupe) input the resulting fragment carries a
+    * [[FragmentIssue.EmptyCollection]] that surfaces as [[SaferisError.InvalidStatement]] at execution. No DB
+    * round-trip on failure.
+    *
+    * {{{
+    *   Query[User].where(_.id).inList(runIds)
+    * }}}
+    */
+  def inList(values: Iterable[T])(using Encoder[T]): Parent =
+    val list      = Placeholder.listTagged(values, helper = "WhereBuilder.inList", origin = Placeholder.captureOrigin())
+    val inSql     = s"${whereAlias.toSql}.${whereColumn.label} IN (${list.sql})"
+    val whereFrag = SqlFragment(inSql, list.writes, issues = list.issues)
+    addPredicate(whereFrag)
+
+  /** NOT IN literal — varargs form for inline values. */
+  def notIn(first: T, rest: T*)(using Encoder[T]): Parent =
+    notInList(first +: rest)
+
+  /** NOT IN literal collection — symmetric to [[inList]]. */
+  def notInList(values: Iterable[T])(using Encoder[T]): Parent =
+    val list = Placeholder.listTagged(values, helper = "WhereBuilder.notInList", origin = Placeholder.captureOrigin())
+    val notInSql  = s"${whereAlias.toSql}.${whereColumn.label} NOT IN (${list.sql})"
+    val whereFrag = SqlFragment(notInSql, list.writes, issues = list.issues)
     addPredicate(whereFrag)
 
 end WhereBuilderOps

--- a/core/src/test/scala/saferis/tests/InCollectionIntegrationSpecs.scala
+++ b/core/src/test/scala/saferis/tests/InCollectionIntegrationSpecs.scala
@@ -1,0 +1,176 @@
+package saferis.tests
+
+import saferis.*
+import saferis.postgres.given
+import saferis.tests.PostgresTestContainer.DataSourceProvider
+import zio.*
+import zio.test.*
+
+/** End-to-end integration tests for the literal `IN` collection helpers — both `WhereBuilderOps.in` / `inList` /
+  * `notIn` / `notInList` on the typed Query DSL and `Interpolator.in` in raw `sql"..."` interpolation.
+  *
+  * Verifies that:
+  *   - Real `IN`/`NOT IN` queries against PostgreSQL return the expected rows.
+  *   - Empty / dedupe behaviour matches the unit-level expectations in InterpolatorSpecs and QuerySpecs.
+  *   - `SaferisError.InvalidStatement` surfaces from `xa.run(...)` without touching the database, and is recoverable
+  *     via `.catchSome`.
+  */
+object InCollectionIntegrationSpecs extends ZIOSpecDefault:
+  val xaLayer = DataSourceProvider.default >>> Transactor.default
+
+  @tableName("in_collection_users")
+  final case class InUser(@key id: Int, name: String) derives Table
+
+  /** DDL + seed: 5 rows with ids 1..5. Idempotent — drops if exists. */
+  private val seedTable: ZIO[Transactor, SaferisError, Unit] =
+    for
+      xa <- ZIO.service[Transactor]
+      _  <- xa.run(sql"drop table if exists in_collection_users".dml)
+      _  <- xa.run(
+        sql"""create table in_collection_users (
+                id integer primary key,
+                name varchar(255) not null
+              )""".dml
+      )
+      _ <- xa.run(sql"insert into in_collection_users (id, name) values (1, 'Alice')".dml)
+      _ <- xa.run(sql"insert into in_collection_users (id, name) values (2, 'Bob')".dml)
+      _ <- xa.run(sql"insert into in_collection_users (id, name) values (3, 'Carol')".dml)
+      _ <- xa.run(sql"insert into in_collection_users (id, name) values (4, 'Dan')".dml)
+      _ <- xa.run(sql"insert into in_collection_users (id, name) values (5, 'Eve')".dml)
+    yield ()
+
+  val tests = suiteAll("IN literal collections — end-to-end"):
+
+    // === Positive paths via Query DSL ===
+
+    test("Query DSL inList(List) returns rows matching the spliced ids"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(Query[InUser].where(_.id).inList(List(2, 4)).query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    test("Query DSL in(varargs) returns rows matching the inline ids"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(Query[InUser].where(_.id).in(2, 4).query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    test("Query DSL inList accepts a Set"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(Query[InUser].where(_.id).inList(Set(2, 4)).query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    test("Query DSL notInList returns rows NOT in the spliced ids"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(Query[InUser].where(_.id).notInList(List(1, 3, 5)).query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    // === Positive paths via raw sql"..." ===
+
+    test("Raw sql with in(List) returns rows matching the spliced ids"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(sql"select * from in_collection_users where id in ${in(List(2, 4))}".query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    test("Raw sql with varargs in(...) returns rows matching the inline ids"):
+      for
+        _    <- seedTable
+        xa   <- ZIO.service[Transactor]
+        rows <- xa.run(sql"select * from in_collection_users where id in ${in(2, 4)}".query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    // === Dedupe end-to-end ===
+
+    test("inList deduplicates so DB receives N distinct parameters, not N*k"):
+      for
+        _  <- seedTable
+        xa <- ZIO.service[Transactor]
+        // 4 duplicates collapse to 2 distinct params
+        rows <- xa.run(Query[InUser].where(_.id).inList(List(2, 2, 4, 4)).query[InUser])
+      yield assertTrue(rows.map(_.id).toSet == Set(2, 4))
+
+    // === Failure paths: empty input fails before JDBC ===
+
+    test("xa.run on empty inList fails with InvalidStatement and does not query"):
+      for
+        _      <- seedTable
+        xa     <- ZIO.service[Transactor]
+        result <- xa.run(Query[InUser].where(_.id).inList(List.empty[Int]).query[InUser]).either
+      yield assertTrue(result match
+        case Left(SaferisError.InvalidStatement(issues)) if issues.size == 1 =>
+          issues.exists {
+            case FragmentIssue.EmptyCollection("WhereBuilder.inList", _) => true
+            case _                                                       => false
+          }
+        case _ => false)
+
+    test("xa.run on empty notInList fails with InvalidStatement"):
+      for
+        _      <- seedTable
+        xa     <- ZIO.service[Transactor]
+        result <- xa.run(Query[InUser].where(_.id).notInList(List.empty[Int]).query[InUser]).either
+      yield assertTrue(result match
+        case Left(SaferisError.InvalidStatement(_)) => true
+        case _                                      => false)
+
+    test("xa.run on raw sql with empty in(...) fails with InvalidStatement tagged 'in'"):
+      for
+        _      <- seedTable
+        xa     <- ZIO.service[Transactor]
+        result <-
+          xa.run(sql"select * from in_collection_users where id in ${in(List.empty[Int])}".query[InUser]).either
+      yield assertTrue(result match
+        case Left(SaferisError.InvalidStatement(issues)) =>
+          issues.exists {
+            case FragmentIssue.EmptyCollection("in", _) => true
+            case _                                      => false
+          }
+        case _ => false)
+
+    test("multi-issue: a query with two empty inList calls accumulates two issues"):
+      for
+        _      <- seedTable
+        xa     <- ZIO.service[Transactor]
+        result <- xa
+          .run(
+            Query[InUser]
+              .where(_.id)
+              .inList(List.empty[Int])
+              .where(_.name)
+              .inList(List.empty[String])
+              .query[InUser]
+          )
+          .either
+      yield assertTrue(result match
+        case Left(SaferisError.InvalidStatement(issues)) => issues.size == 2
+        case _                                           => false)
+
+    test(".catchSome recovers cleanly from InvalidStatement without touching DB"):
+      for
+        _  <- seedTable
+        xa <- ZIO.service[Transactor]
+        // Use empty input on purpose; recover with an empty result.
+        rows <- xa
+          .run(Query[InUser].where(_.id).inList(List.empty[Int]).query[InUser])
+          .catchSome { case _: SaferisError.InvalidStatement => ZIO.succeed(Chunk.empty[InUser]) }
+      yield assertTrue(rows.isEmpty)
+
+    test("SqlFragment.validate fails directly without invoking the runtime executor"):
+      val frag = Query[InUser].where(_.id).inList(List.empty[Int]).build
+      for result <- frag.validate.either
+      yield assertTrue(result match
+        case Left(SaferisError.InvalidStatement(_)) => true
+        case _                                      => false)
+
+  end tests
+
+  val spec = suite("InCollectionIntegrationSpecs")(tests).provideShared(xaLayer) @@ TestAspect.sequential
+end InCollectionIntegrationSpecs

--- a/core/src/test/scala/saferis/tests/InterpolatorSpecs.scala
+++ b/core/src/test/scala/saferis/tests/InterpolatorSpecs.scala
@@ -108,4 +108,176 @@ object InterpolatorSpecs extends ZIOSpecDefault:
           query.sql == "SELECT * FROM \"users\" WHERE \"name\" = ?"
         }
 
+      // === Placeholder.list ===
+
+      test("Placeholder.list produces comma-separated placeholders"):
+        val ph = Placeholder.list(List(1, 2, 3))
+        assertTrue(ph.sql == "?, ?, ?", ph.writes.size == 3, ph.issues.isEmpty)
+
+      test("Placeholder.list single-element edge"):
+        val ph = Placeholder.list(List("only"))
+        assertTrue(ph.sql == "?", ph.writes.size == 1)
+
+      test("Placeholder.list varargs overload matches Iterable form"):
+        val viaVarargs  = Placeholder.list(1, 2, 3)
+        val viaIterable = Placeholder.list(List(1, 2, 3))
+        assertTrue(viaVarargs.sql == viaIterable.sql, viaVarargs.writes.size == viaIterable.writes.size)
+
+      test("Placeholder.list deduplicates"):
+        val ph = Placeholder.list(List("a", "a", "b", "b", "c"))
+        assertTrue(ph.sql == "?, ?, ?", ph.writes.size == 3)
+
+      // === in (top-level helper) ===
+
+      test("in with Iterable produces parenthesized placeholders"):
+        val ph = in(List("a", "b", "c"))
+        assertTrue(ph.sql == "(?, ?, ?)", ph.writes.size == 3, ph.issues.isEmpty)
+
+      test("in with single element"):
+        val ph = in(List("only"))
+        assertTrue(ph.sql == "(?)", ph.writes.size == 1)
+
+      test("in varargs"):
+        val ph = in("active", "pending")
+        assertTrue(ph.sql == "(?, ?)", ph.writes.size == 2)
+
+      test("in varargs single arg"):
+        val ph = in(42)
+        assertTrue(ph.sql == "(?)", ph.writes.size == 1)
+
+      test("in inside a real fragment"):
+        val frag = sql"select * from t where x in ${in(List(1, 2))}"
+        assertTrue(frag.sql == "select * from t where x in (?, ?)", frag.writes.size == 2)
+
+      // === collection-type variety ===
+
+      test("in accepts Vector"):
+        val ph = in(Vector(1, 2, 3))
+        assertTrue(ph.sql == "(?, ?, ?)", ph.writes.size == 3)
+
+      test("in accepts Set (count only — order unspecified)"):
+        val ph = in(Set(1, 2, 3))
+        assertTrue(ph.writes.size == 3, ph.sql == "(?, ?, ?)")
+
+      test("in preserves LinkedHashSet insertion order"):
+        val lhs  = scala.collection.mutable.LinkedHashSet("a", "b", "c")
+        val ph   = in(lhs)
+        val show = sql"x in $ph".show
+        assertTrue(show == "x in ('a', 'b', 'c')")
+
+      test("in with SortedSet emits sorted order"):
+        val ss   = scala.collection.immutable.SortedSet(3, 1, 2)
+        val ph   = in(ss)
+        val show = sql"x in $ph".show
+        assertTrue(show == "x in (1, 2, 3)")
+
+      test("in accepts a Range"):
+        val ph = in(1 to 3)
+        assertTrue(ph.writes.size == 3, ph.sql == "(?, ?, ?)")
+
+      // === dedupe ===
+
+      test("in deduplicates"):
+        val ph   = in(List(1, 1, 2, 2, 3))
+        val show = sql"x in $ph".show
+        assertTrue(ph.sql == "(?, ?, ?)", ph.writes.size == 3, show == "x in (1, 2, 3)")
+
+      test("Placeholder.list dedupes single-element collapse"):
+        val ph = Placeholder.list(List("a", "a"))
+        assertTrue(ph.sql == "?", ph.writes.size == 1)
+
+      test("in with all-duplicates collapses to one and is NOT an error"):
+        val ph = in(List(1, 1, 1))
+        assertTrue(ph.sql == "(?)", ph.writes.size == 1, ph.issues.isEmpty)
+
+      // === negative: empty (issue accumulation) ===
+
+      test("in(empty) returns placeholder with EmptyCollection issue tagged 'in'"):
+        val ph = in(List.empty[String])
+        assertTrue(
+          ph.issues.size == 1,
+          ph.issues.exists {
+            case FragmentIssue.EmptyCollection("in", origin) => origin.isDefined
+            case _                                           => false
+          },
+        )
+
+      test("Placeholder.list(empty) issue tagged 'Placeholder.list'"):
+        val ph = Placeholder.list(List.empty[String])
+        assertTrue(
+          ph.issues.size == 1,
+          ph.issues.exists {
+            case FragmentIssue.EmptyCollection("Placeholder.list", _) => true
+            case _                                                    => false
+          },
+        )
+
+      test("in degenerate-empty-after-filter yields one issue"):
+        val ph = in(List(1, 2, 3).filter(_ > 100))
+        assertTrue(ph.issues.size == 1)
+
+      test("fragment with one in(empty) carries one issue and validate fails"):
+        val frag = sql"select * from t where x in ${in(List.empty[Int])}"
+        for result <- frag.validate.either
+        yield assertTrue(
+          frag.issues.size == 1,
+          result match
+            case Left(SaferisError.InvalidStatement(List(FragmentIssue.EmptyCollection("in", _)))) => true
+            case _                                                                                 => false,
+        )
+
+      test("multi-issue accumulation: two empty in() splices yield two issues"):
+        val frag =
+          sql"select * from t where a in ${in(List.empty[Int])} or b in ${in(List.empty[Int])}"
+        for result <- frag.validate.either
+        yield assertTrue(
+          frag.issues.size == 2,
+          result match
+            case Left(SaferisError.InvalidStatement(issues)) if issues.size == 2 =>
+              issues.forall:
+                case FragmentIssue.EmptyCollection("in", _) => true
+                case _                                      => false
+            case _ => false,
+        )
+
+      test("mix valid + invalid in() splices: writes from valid, issues from invalid"):
+        val frag = sql"select * from t where a in ${in(List(1, 2))} or b in ${in(List.empty[Int])}"
+        assertTrue(frag.writes.size == 2, frag.issues.size == 1)
+
+      test("origin frame is non-null and outside the saferis package"):
+        val ph = in(List.empty[Int])
+        assertTrue(ph.issues.exists {
+          case FragmentIssue.EmptyCollection(_, Some(frame)) =>
+            frame.getFileName != null && !frame.getClassName.startsWith("saferis.")
+          case _ => false
+        })
+
+      // === macro interaction: parameter ordering ===
+
+      test("mixed splice keeps writes in argument order"):
+        val name = "Bob"
+        val ids  = List(10, 20, 30)
+        val age  = 42
+        val frag = sql"select * from t where a = $name and b in ${in(ids)} and c = $age"
+        assertTrue(
+          frag.sql == "select * from t where a = ? and b in (?, ?, ?) and c = ?",
+          frag.writes.size == 5,
+          frag.show == "select * from t where a = 'Bob' and b in (10, 20, 30) and c = 42",
+        )
+
+      test("two in() splices keep ordering across argument positions"):
+        val xs   = List(1, 2)
+        val ys   = List(3, 4, 5)
+        val frag = sql"... a in ${in(xs)} and b in ${in(ys)}"
+        assertTrue(
+          frag.sql == "... a in (?, ?) and b in (?, ?, ?)",
+          frag.writes.size == 5,
+          frag.show == "... a in (1, 2) and b in (3, 4, 5)",
+        )
+
+      test("SqlFragment.validate succeeds for valid fragments"):
+        val frag = sql"select 1"
+        for result <- frag.validate
+        yield assertTrue(result == frag)
+
 end InterpolatorSpecs

--- a/core/src/test/scala/saferis/tests/QuerySpecs.scala
+++ b/core/src/test/scala/saferis/tests/QuerySpecs.scala
@@ -277,7 +277,7 @@ object QuerySpecs extends ZIOSpecDefault:
     suite("IN Subqueries")(
       test("simple IN subquery") {
         val subquery = Query[Order].select(_.userId)
-        val q        = Query[User].where(_.id).in(subquery)
+        val q        = Query[User].where(_.id).inSubquery(subquery)
         val sql      = q.build.sql
         assertTrue(
           sql.contains("IN (select userId from orders as orders_ref_1)")
@@ -285,7 +285,7 @@ object QuerySpecs extends ZIOSpecDefault:
       },
       test("IN subquery with where clause") {
         val subquery = Query[Order].where(_.status).eq("paid").select(_.userId)
-        val q        = Query[User].where(_.id).in(subquery)
+        val q        = Query[User].where(_.id).inSubquery(subquery)
         val sql      = q.build.sql
         assertTrue(
           sql.contains("IN (select userId from orders as orders_ref_1 where"),
@@ -294,11 +294,100 @@ object QuerySpecs extends ZIOSpecDefault:
       },
       test("NOT IN subquery") {
         val subquery = Query[Order].select(_.userId)
-        val q        = Query[User].where(_.id).notIn(subquery)
+        val q        = Query[User].where(_.id).notInSubquery(subquery)
         val sql      = q.build.sql
         assertTrue(
           sql.contains("NOT IN (select userId from orders as orders_ref_1)")
         )
+      },
+      test("inList with a Iterable produces parameterized IN") {
+        val q = Query[User].where(_.id).inList(List(1, 2, 3)).build
+        assertTrue(q.sql.contains("IN (?, ?, ?)"), q.writes.size == 3, q.issues.isEmpty)
+      },
+      test("notInList produces parameterized NOT IN") {
+        val q = Query[User].where(_.id).notInList(List(1, 2, 3)).build
+        assertTrue(q.sql.contains("NOT IN (?, ?, ?)"), q.writes.size == 3)
+      },
+      test("in varargs produces parameterized IN") {
+        val q = Query[User].where(_.name).in("active", "pending").build
+        assertTrue(q.sql.contains("IN (?, ?)"), q.writes.size == 2)
+      },
+      test("notIn varargs produces parameterized NOT IN") {
+        val q = Query[User].where(_.name).notIn("archived").build
+        assertTrue(q.sql.contains("NOT IN (?)"), q.writes.size == 1)
+      },
+      test("inList with single element") {
+        val q = Query[User].where(_.id).inList(List(42)).build
+        assertTrue(q.sql.contains("IN (?)"), q.writes.size == 1)
+      },
+      test("inList accepts a Set") {
+        val q = Query[User].where(_.id).inList(Set(1, 2, 3)).build
+        assertTrue(q.writes.size == 3, q.sql.contains("IN (?, ?, ?)"))
+      },
+      test("inList accepts a Vector") {
+        val q = Query[User].where(_.id).inList(Vector(1, 2, 3)).build
+        assertTrue(q.writes.size == 3, q.sql.contains("IN (?, ?, ?)"))
+      },
+      test("inList deduplicates input") {
+        val q = Query[User].where(_.id).inList(List(1, 1, 2)).build
+        assertTrue(q.writes.size == 2, q.sql.contains("IN (?, ?)"))
+      },
+      test("varargs in dedupes too") {
+        val q = Query[User].where(_.id).in(1, 1, 2, 2, 3).build
+        assertTrue(q.writes.size == 3, q.sql.contains("IN (?, ?, ?)"))
+      },
+      test("inSubquery still works alongside the literal in/inList overloads") {
+        val subquery = Query[Order].select(_.userId)
+        val q        = Query[User].where(_.id).inSubquery(subquery).build
+        assertTrue(q.sql.contains("IN (select"), q.issues.isEmpty)
+      },
+      test("inList mixed with other where predicates preserves parameter order") {
+        val q = Query[User].where(_.name).eq("Bob").where(_.id).inList(List(1, 2, 3)).build
+        assertTrue(q.sql.contains("name = ?"), q.sql.contains("IN (?, ?, ?)"), q.writes.size == 4)
+      },
+      test("two inList calls on different columns accumulate writes") {
+        val q = Query[User].where(_.id).inList(List(1, 2)).where(_.name).inList(List("a", "b", "c")).build
+        assertTrue(q.writes.size == 5)
+      },
+      test("inList(empty) does not throw — fragment carries one issue tagged WhereBuilder.inList") {
+        val q = Query[User].where(_.id).inList(List.empty[Int]).build
+        assertTrue(
+          q.issues.size == 1,
+          q.issues.exists {
+            case FragmentIssue.EmptyCollection("WhereBuilder.inList", _) => true
+            case _                                                       => false
+          },
+        )
+      },
+      test("notInList(empty) carries one issue tagged WhereBuilder.notInList") {
+        val q = Query[User].where(_.id).notInList(List.empty[Int]).build
+        assertTrue(
+          q.issues.size == 1,
+          q.issues.exists {
+            case FragmentIssue.EmptyCollection("WhereBuilder.notInList", _) => true
+            case _                                                          => false
+          },
+        )
+      },
+      test("all-duplicates collapsing to one is NOT an error") {
+        val q = Query[User].where(_.id).inList(List(7, 7, 7)).build
+        assertTrue(q.issues.isEmpty, q.writes.size == 1, q.sql.contains("IN (?)"))
+      },
+      test("two empty inList calls produce two accumulated issues") {
+        val q = Query[User].where(_.id).inList(List.empty[Int]).where(_.name).inList(List.empty[String]).build
+        assertTrue(q.issues.size == 2)
+      },
+      test("SqlFragment.validate succeeds for a valid query") {
+        val q = Query[User].where(_.id).inList(List(1, 2)).build
+        for r <- q.validate
+        yield assertTrue(r == q)
+      },
+      test("SqlFragment.validate fails with InvalidStatement for an empty inList") {
+        val q = Query[User].where(_.id).inList(List.empty[Int]).build
+        for r <- q.validate.either
+        yield assertTrue(r match
+          case Left(SaferisError.InvalidStatement(issues)) if issues.size == 1 => true
+          case _                                                               => false)
       },
       test("select modifies query to select specific column") {
         val q   = Query[User].select(_.id)

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -32,7 +32,7 @@ A comprehensive guide to Saferis - the type-safe, resource-safe SQL client libra
 Add Saferis to your `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.russwyte" %% "saferis" % "0.13.0"
+libraryDependencies += "io.github.russwyte" %% "saferis" % "0.13.0+1-1f2cda38"
 ```
 
 Saferis requires ZIO as a provided dependency:
@@ -201,7 +201,8 @@ val minPrice = 10.0
 val query = sql"SELECT * FROM $products WHERE ${products.price} > $minPrice"
 // query: SqlFragment = SqlFragment(
 //   sql = "SELECT * FROM products WHERE price > ?",
-//   writes = Vector(saferis.Write@392c17ac)
+//   writes = Vector(saferis.Write@1e31bdd1),
+//   issues = List()
 // )
 query.show
 // res8: String = "SELECT * FROM products WHERE price > 10.0"
@@ -1021,7 +1022,7 @@ run {
   yield jobs)
 }
 // res50: Chunk[Job] = IndexedSeq(
-//   Job(id = 1, status = "pending", retryAt = Some(2026-05-15T21:23:51.354198Z)),
+//   Job(id = 1, status = "pending", retryAt = Some(2026-05-16T17:24:56.773426Z)),
 //   Job(id = 2, status = "completed", retryAt = None)
 // )
 ```
@@ -2017,7 +2018,7 @@ case class ClaimTask(
 ```scala
 // Query for unclaimed or expired claims
 val now = java.time.Instant.now()
-// now: Instant = 2026-05-15T21:23:51.736858471Z
+// now: Instant = 2026-05-16T17:24:57.191810010Z
 Update[ClaimTask]
   .set(_.claimedBy, Some("worker-1"))
   .where(_.deadline).lte(now)
@@ -2064,7 +2065,7 @@ case class LockRow(
 ```scala
 // returningAs provides type-safe query execution
 val newExpiry = java.time.Instant.now().plusSeconds(60)
-// newExpiry: Instant = 2026-05-15T21:24:51.739130947Z
+// newExpiry: Instant = 2026-05-16T17:25:57.194319765Z
 Update[LockRow]
   .set(_.expiresAt, newExpiry)
   .where(_.instanceId).eq("instance-1")
@@ -2525,18 +2526,18 @@ val activeUserIds = Query[SubOrder]
 //     wherePredicates = Vector(
 //       SqlFragment(
 //         sql = "sub_orders_ref_1.status = ?",
-//         writes = Vector(saferis.Write@3a33d011)
+//         writes = Vector(saferis.Write@11b420d3),
+//         issues = List()
 //       )
 //     ),
 //     sorts = Vector(),
 //     seeks = Vector(),
 //     limitValue = None,
 //     offsetValue = None,
-//     selectColumns = Vector(
 // ...
 
 Query[SubUser]
-  .where(_.id).in(activeUserIds)  // Compiles: both are Int
+  .where(_.id).inSubquery(activeUserIds)  // Compiles: both are Int
   .build.sql
 // res134: String = "select * from sub_users as sub_users_ref_1 where sub_users_ref_1.id IN (select userId from sub_orders as sub_orders_ref_1 where sub_orders_ref_1.status = ?)"
 ```
@@ -2544,12 +2545,67 @@ Query[SubUser]
 ```scala
 // NOT IN subquery
 Query[SubUser]
-  .where(_.id).notIn(activeUserIds)
+  .where(_.id).notInSubquery(activeUserIds)
   .build.sql
 // res135: String = "select * from sub_users as sub_users_ref_1 where sub_users_ref_1.id NOT IN (select userId from sub_orders as sub_orders_ref_1 where sub_orders_ref_1.status = ?)"
 ```
 
 The type safety is enforced at compile time - if the column types don't match, it won't compile.
+
+### IN Literal Collections
+
+For IN-clauses over runtime values (not subqueries), use `in` (varargs) for inline literals or `inList` for any
+`Iterable[T]`. Both work in the typed Query DSL and via the top-level `in(...)` helper inside `sql"..."` interpolation.
+
+```scala
+// Varargs form — natural for inline literals
+Query[SubUser]
+  .where(_.name).in("Alice", "Bob")
+  .build.sql
+// res136: String = "select * from sub_users as sub_users_ref_1 where sub_users_ref_1.name IN (?, ?)"
+```
+
+```scala
+// Iterable form — for runtime collections (List, Set, Vector, LinkedHashSet, ranges, ...)
+val ids = List(1, 2, 3, 3)  // duplicates are removed automatically
+// ids: List[Int] = List(1, 2, 3, 3)
+Query[SubUser]
+  .where(_.id).inList(ids)
+  .build.sql
+// res137: String = "select * from sub_users as sub_users_ref_1 where sub_users_ref_1.id IN (?, ?, ?)"
+```
+
+```scala
+// Same helpers in raw sql"..." interpolation:
+sql"select * from sub_users where id in ${in(ids)}".sql
+// res138: String = "select * from sub_users where id in (?, ?, ?)"
+sql"select * from sub_users where name in ${in("Alice", "Bob")}".sql
+// res139: String = "select * from sub_users where name in (?, ?)"
+```
+
+`notIn` / `notInList` are symmetric. `inSubquery` / `notInSubquery` (renamed from `in`/`notIn` on `SelectQuery`) cover
+the subquery case shown above.
+
+#### Empty collections fail at construction, not in the database
+
+An empty (or all-duplicates-collapse-to-empty) input would produce invalid SQL (`IN ()`) on every supported dialect.
+Saferis does **not** throw at the call site — instead the resulting fragment carries one
+`FragmentIssue.EmptyCollection` per offending helper. When the fragment is run, execution fails with
+`SaferisError.InvalidStatement(issues)` *before* any JDBC call:
+
+```scala
+import zio.*
+
+// Recovery pattern for possibly-empty collections — no DB round-trip on failure:
+val ids2 = List.empty[Int]
+val recovered =
+  xa.run(Query[SubUser].where(_.id).inList(ids2).query[SubUser])
+    .catchSome { case _: SaferisError.InvalidStatement => ZIO.succeed(Chunk.empty[SubUser]) }
+```
+
+If you want to surface issues independently of execution, call `fragment.validate` on any `SqlFragment` — it succeeds
+with the fragment if there are no issues, fails with `InvalidStatement(issues)` otherwise. Multiple offending splices
+in a single statement accumulate into the same `InvalidStatement`, so you fix them all at once.
 
 ### EXISTS Subqueries
 
@@ -2560,7 +2616,7 @@ Use `whereExists()` or `whereNotExists()`:
 Query[SubUser]
   .whereExists(Query[SubOrder].all)
   .build.sql
-// res136: String = "select * from sub_users as sub_users_ref_1 where EXISTS (select * from sub_orders as sub_orders_ref_1)"
+// res140: String = "select * from sub_users as sub_users_ref_1 where EXISTS (select * from sub_orders as sub_orders_ref_1)"
 ```
 
 ```scala
@@ -2568,7 +2624,7 @@ Query[SubUser]
 Query[SubUser]
   .whereNotExists(Query[SubOrder].where(_.status).eq("cancelled"))
   .build.sql
-// res137: String = "select * from sub_users as sub_users_ref_1 where NOT EXISTS (select * from sub_orders as sub_orders_ref_1 where sub_orders_ref_1.status = ?)"
+// res141: String = "select * from sub_users as sub_users_ref_1 where NOT EXISTS (select * from sub_orders as sub_orders_ref_1 where sub_orders_ref_1.status = ?)"
 ```
 
 ### Correlated Subqueries
@@ -2615,7 +2671,7 @@ Query[SubUser]
     Query[SubOrder].where(sql"userId = ${users.id}")
   )
   .build.sql
-// res138: String = "select * from sub_users as sub_users_ref_1 where EXISTS (select * from sub_orders as sub_orders_ref_1 where userId = id)"
+// res142: String = "select * from sub_users as sub_users_ref_1 where EXISTS (select * from sub_orders as sub_orders_ref_1 where userId = id)"
 ```
 
 ### Derived Tables
@@ -2698,7 +2754,7 @@ val highValueOrders = Query[DerivedOrder]
 Query.from(highValueOrders, "high_value")
   .where(_.userId).gt(0)
   .build.sql
-// res140: String = "select * from (select * from derived_orders as derived_orders_ref_1 where derived_orders_ref_1.amount > ?) as high_value where high_value.userId > ?"
+// res144: String = "select * from (select * from derived_orders as derived_orders_ref_1 where derived_orders_ref_1.amount > ?) as high_value where high_value.userId > ?"
 ```
 
 ```scala
@@ -2707,7 +2763,7 @@ Query.from(highValueOrders, "summary")
   .innerJoin[DerivedUser].on(_.userId).eq(_.id)
   .all
   .build.sql
-// res141: String = "select * from (select * from derived_orders as derived_orders_ref_1 where derived_orders_ref_1.amount > ?) as summary inner join derived_users as derived_users_ref_1 on summary.userId = derived_users_ref_1.id"
+// res145: String = "select * from (select * from derived_orders as derived_orders_ref_1 where derived_orders_ref_1.amount > ?) as summary inner join derived_users as derived_users_ref_1 on summary.userId = derived_users_ref_1.id"
 ```
 
 ### Complex Nested Subqueries
@@ -2765,7 +2821,8 @@ val electronicProductIds = Query[ComplexProduct]
 //     wherePredicates = Vector(
 //       SqlFragment(
 //         sql = "complex_products_ref_1.category = ?",
-//         writes = Vector(saferis.Write@331bea30)
+//         writes = Vector(saferis.Write@4e2a6d10),
+//         issues = List()
 //       )
 //     ),
 //     sorts = Vector(),
@@ -2781,11 +2838,10 @@ val electronicProductIds = Query[ComplexProduct]
 //         isNullable = false,
 //         defaultValue = None,
 //         tableAlias = Some(Alias("complex_products_ref_1"))
-//       )
 // ...
 
 val usersWithElectronics = Query[ComplexOrder]
-  .where(_.productId).in(electronicProductIds)
+  .where(_.productId).inSubquery(electronicProductIds)
   .select(_.userId)
 // usersWithElectronics: SelectQuery[Int] = SelectQuery(
 //   Query1Ready(
@@ -2828,19 +2884,19 @@ val usersWithElectronics = Query[ComplexOrder]
 //     wherePredicates = Vector(
 //       SqlFragment(
 //         sql = "complex_orders_ref_1.productId IN (select id from complex_products as complex_products_ref_1 where complex_products_ref_1.category = ?)",
-//         writes = List(saferis.Write@331bea30)
+//         writes = List(saferis.Write@4e2a6d10),
+//         issues = List()
 //       )
 //     ),
 //     sorts = Vector(),
 //     seeks = Vector(),
 //     limitValue = None,
-//     offsetValue = None,
 // ...
 
 Query[ComplexUser]
-  .where(_.id).in(usersWithElectronics)
+  .where(_.id).inSubquery(usersWithElectronics)
   .build.sql
-// res143: String = "select * from complex_users as complex_users_ref_1 where complex_users_ref_1.id IN (select userId from complex_orders as complex_orders_ref_1 where complex_orders_ref_1.productId IN (select id from complex_products as complex_products_ref_1 where complex_products_ref_1.category = ?))"
+// res147: String = "select * from complex_users as complex_users_ref_1 where complex_users_ref_1.id IN (select userId from complex_orders as complex_orders_ref_1 where complex_orders_ref_1.productId IN (select id from complex_products as complex_products_ref_1 where complex_products_ref_1.category = ?))"
 ```
 
 ### Operator Reference
@@ -2883,12 +2939,12 @@ case class TimeoutRow(
 ```scala
 // Find rows that are due AND either unclaimed or with expired claims
 val now = java.time.Instant.now()
-// now: Instant = 2026-05-15T21:23:51.790211218Z
+// now: Instant = 2026-05-16T17:24:57.253612928Z
 Query[TimeoutRow]
   .where(_.deadline).lte(now)
   .andWhere(w => w(_.claimedBy).isNull.or(_.claimedUntil).lt(Some(now)))
   .build.sql
-// res145: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.deadline <= ? and (timeout_rows_ref_1.claimedBy IS NULL OR timeout_rows_ref_1.claimedUntil < ?)"
+// res149: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.deadline <= ? and (timeout_rows_ref_1.claimedBy IS NULL OR timeout_rows_ref_1.claimedUntil < ?)"
 ```
 
 This generates: `SELECT ... WHERE deadline <= ? AND (claimed_by IS NULL OR claimed_until < ?)`
@@ -2909,7 +2965,7 @@ Query[TimeoutRow]
       .or(_.deadline).gt(now)
   )
   .build.sql
-// res146: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.id > ? and (timeout_rows_ref_1.claimedBy IS NULL OR timeout_rows_ref_1.claimedUntil < ? OR timeout_rows_ref_1.deadline > ?)"
+// res150: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.id > ? and (timeout_rows_ref_1.claimedBy IS NULL OR timeout_rows_ref_1.claimedUntil < ? OR timeout_rows_ref_1.deadline > ?)"
 ```
 
 ```scala
@@ -2921,7 +2977,7 @@ Query[TimeoutRow]
       .and(_.claimedUntil).gt(Some(now))
   )
   .build.sql
-// res147: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.id > ? and (timeout_rows_ref_1.claimedBy IS NOT NULL AND timeout_rows_ref_1.claimedUntil > ?)"
+// res151: String = "select * from timeout_rows as timeout_rows_ref_1 where timeout_rows_ref_1.id > ? and (timeout_rows_ref_1.claimedBy IS NOT NULL AND timeout_rows_ref_1.claimedUntil > ?)"
 ```
 
 Available operations in the `andWhere` builder:
@@ -2970,7 +3026,7 @@ run {
     result <- Query[StreamEvent].all.queryStream[StreamEvent].runCollect
   yield result)
 }
-// res149: Chunk[StreamEvent] = IndexedSeq(
+// res153: Chunk[StreamEvent] = IndexedSeq(
 //   StreamEvent(id = 1, name = "event1", payload = "data1"),
 //   StreamEvent(id = 2, name = "event2", payload = "data2"),
 //   StreamEvent(id = 3, name = "event3", payload = "data3")
@@ -2999,7 +3055,7 @@ run {
     first2 <- Query[StreamEvent].all.queryStream[StreamEvent].take(2).runCollect
   yield first2)
 }
-// res150: Chunk[StreamEvent] = IndexedSeq(
+// res154: Chunk[StreamEvent] = IndexedSeq(
 //   StreamEvent(id = 1, name = "event1", payload = "data1"),
 //   StreamEvent(id = 2, name = "event2", payload = "data2")
 // )
@@ -3026,7 +3082,7 @@ run {
       .runCollect
   yield (names, batches.map(_.size)))
 }
-// res151: Tuple2[Chunk[String], Chunk[Int]] = (
+// res155: Tuple2[Chunk[String], Chunk[Int]] = (
 //   IndexedSeq("event1", "event2", "event3", "event4", "event5"),
 //   IndexedSeq(2, 2, 1)
 // )
@@ -3073,7 +3129,7 @@ run {
       .runCollect
   )
 }
-// res153: Chunk[StreamEvent] = IndexedSeq(
+// res157: Chunk[StreamEvent] = IndexedSeq(
 //   StreamEvent(id = 1, name = "event1", payload = "data1")
 // )
 ```
@@ -3092,7 +3148,7 @@ run {
       .runCollect
   )
 }
-// res154: Chunk[StreamEvent] = IndexedSeq(
+// res158: Chunk[StreamEvent] = IndexedSeq(
 //   StreamEvent(id = 1, name = "event1", payload = "data1")
 // )
 ```
@@ -3134,7 +3190,7 @@ run {
     }
   yield zipped.map((u, i) => s"${u.name} -> ${i.value}"))
 }
-// res156: Chunk[String] = IndexedSeq("Alice -> Item A", "Bob -> Item B")
+// res160: Chunk[String] = IndexedSeq("Alice -> Item A", "Bob -> Item B")
 ```
 
 ---
@@ -3179,7 +3235,7 @@ run {
       .runCollect
   yield pages.map(p => s"Page ${p.pageNumber}: ${p.items.size} items, cursor=${p.cursor}"))
 }
-// res158: Chunk[String] = IndexedSeq(
+// res162: Chunk[String] = IndexedSeq(
 //   "Page 0: 2 items, cursor=Some(2)",
 //   "Page 1: 2 items, cursor=Some(4)",
 //   "Page 2: 1 items, cursor=Some(5)"
@@ -3213,7 +3269,7 @@ run {
     finalCursor <- checkpoint.get
   yield s"Final cursor: $finalCursor")
 }
-// res159: String = "Final cursor: Some(5)"
+// res163: String = "Final cursor: Some(5)"
 ```
 
 ### Resuming from a Checkpoint
@@ -3237,7 +3293,7 @@ run {
       .runCollect
   yield (s"Saved cursor: $savedCursor", s"Remaining pages: ${remaining.size}"))
 }
-// res160: Tuple2[String, String] = (
+// res164: Tuple2[String, String] = (
 //   "Saved cursor: Some(2)",
 //   "Remaining pages: 2"
 // )
@@ -3256,7 +3312,7 @@ run {
       .map(items => s"Got ${items.size} items")
   )
 }
-// res161: String = "Got 5 items"
+// res165: String = "Got 5 items"
 ```
 
 ### Flattening Pages to Items
@@ -3273,7 +3329,7 @@ run {
       .map(items => s"Got ${items.size} items")
   )
 }
-// res162: String = "Got 5 items"
+// res166: String = "Got 5 items"
 ```
 
 ### Items with Checkpoint Callback
@@ -3295,7 +3351,7 @@ run {
     recorded <- checkpoints.get
   yield (s"Processed ${items.size} items", s"Checkpoints: ${recorded.toList}"))
 }
-// res163: Tuple2[String, String] = (
+// res167: Tuple2[String, String] = (
 //   "Processed 5 items",
 //   "Checkpoints: List(Some(2), Some(4), Some(5))"
 // )
@@ -3326,7 +3382,7 @@ run {
       .map(items => s"Unprocessed: ${items.size}")
   )
 }
-// res164: String = "Unprocessed: 5"
+// res168: String = "Unprocessed: 5"
 ```
 
 ### Resource Safety
@@ -3383,7 +3439,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(_.sequenceNr)(_.max)
   .build.sql
-// res167: String = "select max(sequenceNr) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res171: String = "select max(sequenceNr) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ```scala
@@ -3392,7 +3448,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(_.amount)(_.min)
   .build.sql
-// res168: String = "select min(amount) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res172: String = "select min(amount) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ```scala
@@ -3401,7 +3457,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(_.amount)(_.sum)
   .build.sql
-// res169: String = "select sum(amount) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res173: String = "select sum(amount) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ```scala
@@ -3410,7 +3466,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(_.sequenceNr)(_.count)
   .build.sql
-// res170: String = "select count(sequenceNr) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res174: String = "select count(sequenceNr) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ```scala
@@ -3419,7 +3475,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(countAll)
   .build.sql
-// res171: String = "select count(*) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res175: String = "select count(*) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ### COALESCE for Default Values
@@ -3432,7 +3488,7 @@ Query[EventRow]
   .where(_.instanceId).eq("instance-1")
   .selectAggregate(_.sequenceNr)(_.max.coalesce(0L))
   .build.sql
-// res172: String = "select coalesce(max(sequenceNr), ?) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res176: String = "select coalesce(max(sequenceNr), ?) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ```scala
@@ -3441,7 +3497,7 @@ Query[EventRow]
   .where(_.instanceId).eq("nonexistent")
   .selectAggregate(_.amount)(_.sum.coalesce(BigDecimal(0)))
   .build.sql
-// res173: String = "select coalesce(sum(amount), ?) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
+// res177: String = "select coalesce(sum(amount), ?) from event_rows as event_rows_ref_1 where event_rows_ref_1.instanceId = ?"
 ```
 
 ### Executing Aggregate Queries
@@ -3469,7 +3525,7 @@ run {
       .queryValue[Long]
   yield (maxSeq, total, count))
 }
-// res174: Tuple3[Option[Long], Option[BigDecimal], Option[Long]] = (
+// res178: Tuple3[Option[Long], Option[BigDecimal], Option[Long]] = (
 //   Some(5L),
 //   Some(450),
 //   Some(3L)
@@ -3512,13 +3568,13 @@ case class UpsertLock(
 ```scala
 // Basic upsert - update all non-key columns on conflict
 val now = java.time.Instant.now()
-// now: Instant = 2026-05-15T21:23:52.124713651Z
+// now: Instant = 2026-05-16T17:24:57.606325191Z
 val lock = UpsertLock("instance-1", "node-1", now, now.plusSeconds(60))
 // lock: UpsertLock = UpsertLock(
 //   instanceId = "instance-1",
 //   nodeId = "node-1",
-//   acquiredAt = 2026-05-15T21:23:52.124713651Z,
-//   expiresAt = 2026-05-15T21:24:52.124713651Z
+//   acquiredAt = 2026-05-16T17:24:57.606325191Z,
+//   expiresAt = 2026-05-16T17:25:57.606325191Z
 // )
 
 Upsert[UpsertLock]
@@ -3526,7 +3582,7 @@ Upsert[UpsertLock]
   .onConflict(_.instanceId)
   .doUpdateAll
   .build.sql
-// res176: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ?"
+// res180: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ?"
 ```
 
 ### Conditional Upsert with WHERE
@@ -3541,7 +3597,7 @@ Upsert[UpsertLock]
   .doUpdateAll
   .where(_.expiresAt).lt(now)
   .build.sql
-// res177: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ?"
+// res181: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ?"
 ```
 
 This generates: `INSERT INTO ... ON CONFLICT (instance_id) DO UPDATE SET ... WHERE upsert_locks.expires_at < ?`
@@ -3559,7 +3615,7 @@ Upsert[UpsertLock]
   .where(_.expiresAt).lt(now)
   .or(_.nodeId).eqExcluded
   .build.sql
-// res178: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ? OR upsert_locks.nodeId = EXCLUDED.nodeId"
+// res182: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ? OR upsert_locks.nodeId = EXCLUDED.nodeId"
 ```
 
 The `.eqExcluded` generates `table.column = EXCLUDED.column`, referencing the value from the INSERT.
@@ -3575,7 +3631,7 @@ Upsert[UpsertLock]
   .onConflict(_.instanceId)
   .doNothing
   .build.sql
-// res179: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do nothing"
+// res183: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do nothing"
 ```
 
 ### Upsert with RETURNING
@@ -3590,7 +3646,7 @@ Upsert[UpsertLock]
   .doUpdateAll
   .returning
   .build.sql
-// res180: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? returning *"
+// res184: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? returning *"
 ```
 
 ```scala
@@ -3602,7 +3658,7 @@ Upsert[UpsertLock]
   .where(_.expiresAt).lt(now)
   .returning
   .build.sql
-// res181: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ? returning *"
+// res185: String = "insert into upsert_locks (instanceId, nodeId, acquiredAt, expiresAt) values (?, ?, ?, ?) on conflict (instanceId) do update set nodeId = ?, acquiredAt = ?, expiresAt = ? WHERE upsert_locks.expiresAt < ? returning *"
 ```
 
 ### Compound Conflict Columns
@@ -3636,7 +3692,7 @@ Upsert[UpsertItem]
   .onConflict(_.tenantId).and(_.sku)
   .doUpdateAll
   .build.sql
-// res183: String = "insert into upsert_items (tenantId, sku, name, quantity) values (?, ?, ?, ?) on conflict (tenantId, sku) do update set name = ?, quantity = ?"
+// res187: String = "insert into upsert_items (tenantId, sku, name, quantity) values (?, ?, ?, ?) on conflict (tenantId, sku) do update set name = ?, quantity = ?"
 ```
 
 ### Full Atomic Lock Acquisition Example
@@ -3685,21 +3741,21 @@ run {
 
   yield (result1, result2))
 }
-// res185: Tuple2[Option[AtomicLock], Option[AtomicLock]] = (
+// res189: Tuple2[Option[AtomicLock], Option[AtomicLock]] = (
 //   Some(
 //     AtomicLock(
 //       instanceId = "lock-1",
 //       nodeId = "node-A",
-//       acquiredAt = 2026-05-15T21:23:52.137642Z,
-//       expiresAt = 2026-05-15T21:24:52.137642Z
+//       acquiredAt = 2026-05-16T17:24:57.619236Z,
+//       expiresAt = 2026-05-16T17:25:57.619236Z
 //     )
 //   ),
 //   Some(
 //     AtomicLock(
 //       instanceId = "lock-1",
 //       nodeId = "node-A",
-//       acquiredAt = 2026-05-15T21:23:52.137642Z,
-//       expiresAt = 2026-05-15T21:25:52.137642Z
+//       acquiredAt = 2026-05-16T17:24:57.619236Z,
+//       expiresAt = 2026-05-16T17:26:57.619236Z
 //     )
 //   )
 // )
@@ -3757,7 +3813,7 @@ run {
     all <- sql"SELECT * FROM ${Table[SpecializedItem]}".query[SpecializedItem]
   yield (inserted, all))
 }
-// res187: Tuple2[SpecializedItem, Chunk[SpecializedItem]] = (
+// res191: Tuple2[SpecializedItem, Chunk[SpecializedItem]] = (
 //   SpecializedItem(id = 1, name = "Widget", category = "hardware"),
 //   IndexedSeq(
 //     SpecializedItem(id = 1, name = "Widget", category = "hardware"),
@@ -3775,7 +3831,7 @@ The `SpecializedDML` object provides operations that require specific dialect ca
 run {
   xa.run(sql"SELECT * FROM ${Table[SpecializedItem]} ORDER BY ${Table[SpecializedItem].id}".query[SpecializedItem])
 }
-// res188: Chunk[SpecializedItem] = IndexedSeq(
+// res192: Chunk[SpecializedItem] = IndexedSeq(
 //   SpecializedItem(id = 1, name = "Widget", category = "hardware"),
 //   SpecializedItem(id = 2, name = "Gadget", category = "electronics")
 // )
@@ -3812,7 +3868,7 @@ Write functions that require specific capabilities using intersection types:
 run {
   xa.run(dml.insertReturning(SpecializedItem(-1, "Capability Demo", "demo")))
 }
-// res189: SpecializedItem = SpecializedItem(
+// res193: SpecializedItem = SpecializedItem(
 //   id = 3,
 //   name = "Capability Demo",
 //   category = "demo"
@@ -3864,20 +3920,20 @@ run {
     all <- sql"SELECT * FROM $events".query[Event]
   yield all)
 }
-// res191: Chunk[Event] = IndexedSeq(
+// res195: Chunk[Event] = IndexedSeq(
 //   Event(
 //     id = 1,
 //     name = "Conference",
-//     occurredAt = 2026-05-15T21:23:52.182038Z,
-//     scheduledFor = Some(2026-05-22T16:23:52.182073),
-//     eventDate = 2026-05-15
+//     occurredAt = 2026-05-16T17:24:57.668176Z,
+//     scheduledFor = Some(2026-05-23T12:24:57.668216),
+//     eventDate = 2026-05-16
 //   ),
 //   Event(
 //     id = 2,
 //     name = "Meeting",
-//     occurredAt = 2026-05-15T21:23:52.186397Z,
+//     occurredAt = 2026-05-16T17:24:57.673015Z,
 //     scheduledFor = None,
-//     eventDate = 2026-05-16
+//     eventDate = 2026-05-17
 //   )
 // )
 ```
@@ -3907,8 +3963,8 @@ run {
     found <- sql"SELECT * FROM $entities WHERE ${entities.id} = $id1".queryOne[Entity]
   yield found)
 }
-// res193: Option[Entity] = Some(
-//   Entity(id = 5cb96193-ba33-4830-933f-699a24c5e076, name = "First Entity")
+// res197: Option[Entity] = Some(
+//   Entity(id = 3d5923a6-310c-4672-a32f-acda182a7530, name = "First Entity")
 // )
 ```
 
@@ -3958,7 +4014,7 @@ run {
     all <- sql"SELECT * FROM $events".query[JsonEvent]
   yield all)
 }
-// res195: Chunk[JsonEvent] = IndexedSeq(
+// res199: Chunk[JsonEvent] = IndexedSeq(
 //   JsonEvent(
 //     id = 1,
 //     name = "Deploy",
@@ -4016,7 +4072,7 @@ run {
     avgPrice <- sql"SELECT AVG(${items.price}) FROM $items".queryValue[Double]
   yield (count, maxPrice, avgPrice))
 }
-// res197: Tuple3[Option[Int], Option[Double], Option[Double]] = (
+// res201: Tuple3[Option[Int], Option[Double], Option[Double]] = (
 //   Some(3),
 //   Some(25.0),
 //   Some(16.666666666666668)
@@ -4055,7 +4111,7 @@ run {
     result <- sql"SELECT * FROM ${Table[ExecItem]}".query[ExecItem]
   yield (insertCount, updateCount, result))
 }
-// res199: Tuple3[Int, Int, Chunk[ExecItem]] = (
+// res203: Tuple3[Int, Int, Chunk[ExecItem]] = (
 //   1,
 //   1,
 //   IndexedSeq(ExecItem(id = 1, name = "Widget", quantity = 20))

--- a/saferis-docs/docs/DOCUMENTATION.md
+++ b/saferis-docs/docs/DOCUMENTATION.md
@@ -2127,18 +2127,68 @@ val activeUserIds = Query[SubOrder]
   .select(_.userId)  // Returns SelectQuery[Int]
 
 Query[SubUser]
-  .where(_.id).in(activeUserIds)  // Compiles: both are Int
+  .where(_.id).inSubquery(activeUserIds)  // Compiles: both are Int
   .build.sql
 ```
 
 ```scala mdoc
 // NOT IN subquery
 Query[SubUser]
-  .where(_.id).notIn(activeUserIds)
+  .where(_.id).notInSubquery(activeUserIds)
   .build.sql
 ```
 
 The type safety is enforced at compile time - if the column types don't match, it won't compile.
+
+### IN Literal Collections
+
+For IN-clauses over runtime values (not subqueries), use `in` (varargs) for inline literals or `inList` for any
+`Iterable[T]`. Both work in the typed Query DSL and via the top-level `in(...)` helper inside `sql"..."` interpolation.
+
+```scala mdoc
+// Varargs form — natural for inline literals
+Query[SubUser]
+  .where(_.name).in("Alice", "Bob")
+  .build.sql
+```
+
+```scala mdoc
+// Iterable form — for runtime collections (List, Set, Vector, LinkedHashSet, ranges, ...)
+val ids = List(1, 2, 3, 3)  // duplicates are removed automatically
+Query[SubUser]
+  .where(_.id).inList(ids)
+  .build.sql
+```
+
+```scala mdoc
+// Same helpers in raw sql"..." interpolation:
+sql"select * from sub_users where id in ${in(ids)}".sql
+sql"select * from sub_users where name in ${in("Alice", "Bob")}".sql
+```
+
+`notIn` / `notInList` are symmetric. `inSubquery` / `notInSubquery` (renamed from `in`/`notIn` on `SelectQuery`) cover
+the subquery case shown above.
+
+#### Empty collections fail at construction, not in the database
+
+An empty (or all-duplicates-collapse-to-empty) input would produce invalid SQL (`IN ()`) on every supported dialect.
+Saferis does **not** throw at the call site — instead the resulting fragment carries one
+`FragmentIssue.EmptyCollection` per offending helper. When the fragment is run, execution fails with
+`SaferisError.InvalidStatement(issues)` *before* any JDBC call:
+
+```scala mdoc:silent
+import zio.*
+
+// Recovery pattern for possibly-empty collections — no DB round-trip on failure:
+val ids2 = List.empty[Int]
+val recovered =
+  xa.run(Query[SubUser].where(_.id).inList(ids2).query[SubUser])
+    .catchSome { case _: SaferisError.InvalidStatement => ZIO.succeed(Chunk.empty[SubUser]) }
+```
+
+If you want to surface issues independently of execution, call `fragment.validate` on any `SqlFragment` — it succeeds
+with the fragment if there are no issues, fails with `InvalidStatement(issues)` otherwise. Multiple offending splices
+in a single statement accumulate into the same `InvalidStatement`, so you fix them all at once.
 
 ### EXISTS Subqueries
 
@@ -2238,11 +2288,11 @@ val electronicProductIds = Query[ComplexProduct]
   .select(_.id)
 
 val usersWithElectronics = Query[ComplexOrder]
-  .where(_.productId).in(electronicProductIds)
+  .where(_.productId).inSubquery(electronicProductIds)
   .select(_.userId)
 
 Query[ComplexUser]
-  .where(_.id).in(usersWithElectronics)
+  .where(_.id).inSubquery(usersWithElectronics)
   .build.sql
 ```
 


### PR DESCRIPTION
## Summary

Adds three layered helpers for IN-clauses over runtime collections so callers no longer have to round-trip through `Encoder[List[T]]`:

- **`Placeholder.list(coll)`** / **`Placeholder.list(a, b, c)`** — produces `?, ?, ?` for VALUES rows and other comma-separated contexts.
- **Top-level `in(coll)`** / **`in(a, b, c)`** — exported from `saferis.*` (like `sql` / `sqlEcho`); wraps the same in parens for IN clauses inside `sql"..."` interpolation.
- **`WhereBuilderOps.in(varargs)`** and **`WhereBuilderOps.inList(Iterable)`** — typed Query DSL, plus matching `notIn` / `notInList`.

Each helper accepts any `Iterable[T]` and dedupes via `.iterator.distinct` before parameter expansion. This honors IN's set semantics and mitigates the Databricks 256-parameter prepared-statement cap for typical run-id lists.

```scala
// Inline literals (varargs):
Query[User].where(_.status).in("active", "pending")
sql"... where id in ${in(1, 2, 3)}"

// Runtime collections (Iterable — Seq, Set, Vector, LinkedHashSet, ranges, ...):
Query[User].where(_.id).inList(runIds)
sql"... where id in ${in(runIds)}"
```

## Failures as typed errors, not throwables

Helpers stay pure; on empty (or degenerate-empty-after-dedupe) input they tag a `FragmentIssue.EmptyCollection` on the resulting fragment. Issues propagate through `++`, `concat`, `join`, `append`, `Query.build`, and `Mutation.build`. At execution, [`SqlFragment`](core/src/main/scala/saferis/SqlFragment.scala) refuses to acquire a JDBC connection and fails with `SaferisError.InvalidStatement(issues)` — **no DB round-trip on invalid input**. Multiple offending splices in a single statement accumulate so callers fix them all at once.

A new public [`SqlFragment.validate`](core/src/main/scala/saferis/SqlFragment.scala) lifts the issue list into a ZIO effect for callers who want to surface failures before execution. Each issue captures a `StackTraceElement` pointing at the user's call site.

```scala
// Recovery pattern — no JDBC interaction on failure:
xa.run(Query[User].where(_.id).inList(maybeEmpty).query[User])
  .catchSome { case _: SaferisError.InvalidStatement => ZIO.succeed(Chunk.empty) }
```

## Breaking Change

`WhereBuilderOps.in(subquery: SelectQuery[T])` and `notIn(subquery)` are renamed to `inSubquery` / `notInSubquery` to free up `in` for the varargs form. Scala 3 keeps the trait's `T` open during overload resolution inside the trait body, which would otherwise make `in(SelectQuery[Int])` ambiguously match a varargs `in(first: T, rest: T*)`. Renaming was the cleanest non-extension path; in-repo callers (4 test sites, 4 doc snippets, 1 scaladoc) are migrated in this PR.

Migration:

```diff
- Query[User].where(_.id).in(orderUserIds)        // orderUserIds: SelectQuery[Int]
+ Query[User].where(_.id).inSubquery(orderUserIds)

- Query[User].where(_.id).notIn(orderUserIds)
+ Query[User].where(_.id).notInSubquery(orderUserIds)
```

## Tests

Coverage at every layer — positive, edge, negative:

- **35 fragment-level cases** in [`InterpolatorSpecs`](core/src/test/scala/saferis/tests/InterpolatorSpecs.scala) — varargs, collection variety (`Seq`/`List`/`Vector`/`Set`/`LinkedHashSet`/`SortedSet`/`Range`), dedupe, single-issue / multi-issue / mixed-valid-and-invalid splices, macro splice ordering, origin-frame capture.
- **18 DSL-level cases** in [`QuerySpecs`](core/src/test/scala/saferis/tests/QuerySpecs.scala) — `in` / `inList` / `notIn` / `notInList`, overload resolution preserves `inSubquery`, dedupe, multi-issue accumulation, `SqlFragment.validate` success / failure.
- **13 end-to-end Postgres testcontainer cases** in the new [`InCollectionIntegrationSpecs`](core/src/test/scala/saferis/tests/InCollectionIntegrationSpecs.scala) — real query results, dedupe end-to-end, failure paths, recovery via `.catchSome`.

**Total: 545 tests passing (baseline was 473).** `scalafmtCheckAll` clean. `docs/mdoc` compiles cleanly with a new "IN Literal Collections" section in [DOCUMENTATION.md](saferis-docs/docs/DOCUMENTATION.md).

## Test plan

- [x] CI: `scalafmtCheckAll`, `core/test`, `docs/mdoc` all green.
- [x] Reviewer spot-check the renamed callers in [`QuerySpecs.scala`](core/src/test/scala/saferis/tests/QuerySpecs.scala) and [`saferis-docs/docs/DOCUMENTATION.md`](saferis-docs/docs/DOCUMENTATION.md) for downstream impact.
- [x] Reviewer eyeball the `validateIssues` wiring in [`SqlFragment.scala`](core/src/main/scala/saferis/SqlFragment.scala) — confirms invalid fragments never reach `connection.prepareStatement`.
- [x] If you have downstream callers of `where(_.col).in(subquery)` outside this repo, plan the rename to `inSubquery` before merging.