### PR TITLE
Bump sbt to 2.0.3

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.1
+sbt.version=2.0.3


### PR DESCRIPTION
## Summary
- Bump `sbt.version` to **2.0.3** (CVE-2026-26032 Ivy backport; Jawn GHSA-cc4v-rvgp-2pf3 / GHSA-w4cm-gvhj-cgw6 via sjson-new).
- CI uses `sbt/setup-sbt`, which installs the version from `project/build.properties`, so workflows pick up 2.0.3 automatically.

## Test plan
- [ ] CI green on this PR