### PR TITLE
Adopt sbt-dynver-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,11 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-test
+          key: ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-test
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-
+            ubuntu-latest-jdk25-sbt-0.18.0-
             ubuntu-latest-jdk25-sbt-
       - name: test
         run: sbt 'test; docs/marklitCompile'
@@ -92,10 +93,11 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-fmt
+          key: ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-fmt
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-
+            ubuntu-latest-jdk25-sbt-0.18.0-
             ubuntu-latest-jdk25-sbt-
       - name: fmt
         run: sbt 'scalafmtCheckAll'
@@ -128,10 +130,11 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-publish
+          key: ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-publish
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-0.18.0-ci-
+            ubuntu-latest-jdk25-sbt-0.18.0-
             ubuntu-latest-jdk25-sbt-
       - name: Import signing key
         run: |

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.6.1")
 addSbtPlugin("rocks.earlyeffect" % "sbt-marklit"   % "0.1.0")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.14.7")
-addSbtPlugin("com.github.sbt"    % "sbt-dynver"    % "5.1.1")
+addSbtPlugin("rocks.earlyeffect" % "sbt-dynver-ci" % "0.2.2")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "2.4.4")
 addSbtPlugin("rocks.earlyeffect" % "sbt-zipx"      % "0.0.10")


### PR DESCRIPTION
Brings saferis onto `sbt-dynver-ci` 0.2.2, replacing stock `sbt-dynver` 5.1.1 (the plugin depends on dynver transitively, so the old line is removed rather than kept alongside). Last of the three repos still on stock dynver; the org now shares one version policy.

Nothing else about saferis changes — still Scala 3.3.8 LTS, no doc-site or Scala-version work here.

## Published artifacts are unchanged

`DynverCiVersion.format` returns the bare version when the tag is clean, so a `v0.18.0` tag still produces exactly `0.18.0`, and publishing is gated on `refs/tags/v` anyway. Only off-tag builds move: `0.18.0+2-713c17ae+20260724-1335` → `0.18.0-ci`.

## Which fixes a live CI problem

zipx's cache key embeds the root version as `cacheEpoch`, so the committed `ci.yml` held a **per-commit timestamp** — in every `restore-keys` prefix too, meaning **every commit missed the cache entirely** and cold-started sbt + coursier:

```
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-test
+          key: ubuntu-latest-jdk25-sbt-0.18.0-ci-${{ github.run_id }}-test
```

Regenerating was required either way — `zipxWorkflowCheck` fails on a stale epoch.

## Verification

Full `sbt test` against real Testcontainers Postgres: **556 passed, 0 failed**. `scalafmtCheckAll` and `zipxWorkflowCheck` clean after regeneration. No `ThisBuild / version` in the build, so the plugin's `buildSettings` value wins uncontested.