### PR TITLE
Adopt sbt-zipx 0.0.12 with dual publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ name: CI
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
   pull_request: null
+concurrency:
+  group: CI-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 jobs:
   verify-gate:
     name: verify-gate
@@ -43,6 +46,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: "0"
+          fetch-tags: "true"
       - name: Setup JDK 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
@@ -51,6 +55,32 @@ jobs:
       - uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
         with:
           disk-cache: "false"
+      - name: Resolve cache epoch
+        id: cache-epoch
+        run: |
+          set -euo pipefail
+          tag_match='v*'
+          if git remote get-url origin >/dev/null 2>&1; then
+            remote_count=$(git ls-remote --tags --refs origin "$tag_match" 2>/dev/null | wc -l | tr -d ' ')
+            local_count=$(git tag -l "$tag_match" | wc -l | tr -d ' ')
+            if [ "$remote_count" -gt 0 ] && [ "$local_count" -lt "$remote_count" ]; then
+              echo "::warning title=zipx cache epoch::Local tags ($local_count) fewer than origin ($remote_count). Epoch may be stale; checkout must use fetch-depth: 0 and fetch-tags: true."
+            fi
+          fi
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            release="${GITHUB_REF#refs/tags/v}"
+            epoch="$release"
+          elif tag=$(git describe --tags --abbrev=0 --match "$tag_match" 2>/dev/null); then
+            release="${tag#v}"
+            epoch="${release}-ci"
+          else
+            echo "::warning title=zipx cache epoch::No tags matching '$tag_match' found; using epoch 0.0.0."
+            release="0.0.0"
+            epoch="0.0.0"
+          fi
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
       - name: Cache sbt
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -59,10 +89,11 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-test
+          key: ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-test
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.release }}-
             ubuntu-latest-jdk25-sbt-
       - name: test
         run: sbt 'test; docs/marklitCompile'
@@ -76,6 +107,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: "0"
+          fetch-tags: "true"
       - name: Setup JDK 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
@@ -84,6 +116,32 @@ jobs:
       - uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
         with:
           disk-cache: "false"
+      - name: Resolve cache epoch
+        id: cache-epoch
+        run: |
+          set -euo pipefail
+          tag_match='v*'
+          if git remote get-url origin >/dev/null 2>&1; then
+            remote_count=$(git ls-remote --tags --refs origin "$tag_match" 2>/dev/null | wc -l | tr -d ' ')
+            local_count=$(git tag -l "$tag_match" | wc -l | tr -d ' ')
+            if [ "$remote_count" -gt 0 ] && [ "$local_count" -lt "$remote_count" ]; then
+              echo "::warning title=zipx cache epoch::Local tags ($local_count) fewer than origin ($remote_count). Epoch may be stale; checkout must use fetch-depth: 0 and fetch-tags: true."
+            fi
+          fi
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            release="${GITHUB_REF#refs/tags/v}"
+            epoch="$release"
+          elif tag=$(git describe --tags --abbrev=0 --match "$tag_match" 2>/dev/null); then
+            release="${tag#v}"
+            epoch="${release}-ci"
+          else
+            echo "::warning title=zipx cache epoch::No tags matching '$tag_match' found; using epoch 0.0.0."
+            release="0.0.0"
+            epoch="0.0.0"
+          fi
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
       - name: Cache sbt
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -92,17 +150,18 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-fmt
+          key: ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-fmt
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.release }}-
             ubuntu-latest-jdk25-sbt-
       - name: fmt
         run: sbt 'scalafmtCheckAll'
   publish:
     name: publish
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: (startsWith(github.ref, 'refs/tags/v')) && (github.repository == 'early-effect/saferis')
     env:
       PGP_KEY_HEX: ${{ secrets.PGP_KEY_HEX }}
       PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -112,6 +171,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: "0"
+          fetch-tags: "true"
       - name: Setup JDK 25
         uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
@@ -120,6 +180,32 @@ jobs:
       - uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
         with:
           disk-cache: "false"
+      - name: Resolve cache epoch
+        id: cache-epoch
+        run: |
+          set -euo pipefail
+          tag_match='v*'
+          if git remote get-url origin >/dev/null 2>&1; then
+            remote_count=$(git ls-remote --tags --refs origin "$tag_match" 2>/dev/null | wc -l | tr -d ' ')
+            local_count=$(git tag -l "$tag_match" | wc -l | tr -d ' ')
+            if [ "$remote_count" -gt 0 ] && [ "$local_count" -lt "$remote_count" ]; then
+              echo "::warning title=zipx cache epoch::Local tags ($local_count) fewer than origin ($remote_count). Epoch may be stale; checkout must use fetch-depth: 0 and fetch-tags: true."
+            fi
+          fi
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            release="${GITHUB_REF#refs/tags/v}"
+            epoch="$release"
+          elif tag=$(git describe --tags --abbrev=0 --match "$tag_match" 2>/dev/null); then
+            release="${tag#v}"
+            epoch="${release}-ci"
+          else
+            echo "::warning title=zipx cache epoch::No tags matching '$tag_match' found; using epoch 0.0.0."
+            release="0.0.0"
+            epoch="0.0.0"
+          fi
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
       - name: Cache sbt
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -128,10 +214,11 @@ jobs:
             ~/.cache/sbt
             ~/.cache/coursier
             target
-          key: ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-publish
+          key: ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-publish
           restore-keys: |
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-${{ github.run_id }}-
-            ubuntu-latest-jdk25-sbt-0.18.0+2-713c17ae+20260724-1335-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.release }}-
             ubuntu-latest-jdk25-sbt-
       - name: Import signing key
         run: |
@@ -143,4 +230,72 @@ jobs:
         env:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
       - name: publish
-        run: sbt '+publishSigned; sonaRelease'
+        run: sbt 'core/publishSigned; sonaRelease'
+  github-packages:
+    name: github-packages
+    runs-on: ubuntu-latest
+    if: (startsWith(github.ref, 'refs/tags/v')) && (github.repository == 'Iterable/saferis')
+    permissions:
+      contents: read
+      packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+      PUBLISH_GITHUB_PACKAGES: "true"
+      PUBLISH_ORG: com.iterable
+      PUBLISH_ORG_NAME: Iterable
+      PUBLISH_PACKAGES_REPO: https://maven.pkg.github.com/iterable/maven-packages
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: "0"
+          fetch-tags: "true"
+      - name: Setup JDK 25
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "25"
+      - uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        with:
+          disk-cache: "false"
+      - name: Resolve cache epoch
+        id: cache-epoch
+        run: |
+          set -euo pipefail
+          tag_match='v*'
+          if git remote get-url origin >/dev/null 2>&1; then
+            remote_count=$(git ls-remote --tags --refs origin "$tag_match" 2>/dev/null | wc -l | tr -d ' ')
+            local_count=$(git tag -l "$tag_match" | wc -l | tr -d ' ')
+            if [ "$remote_count" -gt 0 ] && [ "$local_count" -lt "$remote_count" ]; then
+              echo "::warning title=zipx cache epoch::Local tags ($local_count) fewer than origin ($remote_count). Epoch may be stale; checkout must use fetch-depth: 0 and fetch-tags: true."
+            fi
+          fi
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            release="${GITHUB_REF#refs/tags/v}"
+            epoch="$release"
+          elif tag=$(git describe --tags --abbrev=0 --match "$tag_match" 2>/dev/null); then
+            release="${tag#v}"
+            epoch="${release}-ci"
+          else
+            echo "::warning title=zipx cache epoch::No tags matching '$tag_match' found; using epoch 0.0.0."
+            release="0.0.0"
+            epoch="0.0.0"
+          fi
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+
+      - name: Cache sbt
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.sbt
+            ~/.cache/sbt
+            ~/.cache/coursier
+            target
+          key: ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-github-packages
+          restore-keys: |
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-${{ github.run_id }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-
+            ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.release }}-
+            ubuntu-latest-jdk25-sbt-
+      - name: github-packages
+        run: sbt 'core/publish'

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 val scala3Version = "3.3.8"
 val zioVersion    = "2.1.26"
 
-// Global settings using ThisBuild scope
+// Global settings. Iterable/saferis overrides group via PUBLISH_ORG from ZipxGitHubPackages.
 ThisBuild / scalaVersion         := scala3Version
-ThisBuild / organization         := "rocks.earlyeffect"
-ThisBuild / organizationName     := "Early Effect"
+ThisBuild / organization         := sys.env.getOrElse("PUBLISH_ORG", "rocks.earlyeffect")
+ThisBuild / organizationName     := sys.env.getOrElse("PUBLISH_ORG_NAME", "Early Effect")
 ThisBuild / organizationHomepage := Some(url("https://www.earlyeffect.rocks"))
 ThisBuild / licenses             := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / homepage             := Some(url("https://github.com/early-effect/saferis"))
@@ -24,32 +24,55 @@ ThisBuild / developers := List(
 )
 ThisBuild / versionScheme := Some("early-semver")
 
-// Publishing to Sonatype's Central Portal. sbt 1.11+ has built-in support via
-// `localStaging` / `publishSigned` / `sonaRelease` — no sbt-sonatype plugin needed.
-ThisBuild / publishTo := {
+// Dual publish: Central by default; GitHub Packages when CI sets PUBLISH_PACKAGES_REPO.
+val githubPackagesRepo: Option[MavenRepository] =
+  sys.env.get("PUBLISH_PACKAGES_REPO").map("GitHub Package Registry" at _)
+
+ThisBuild / credentials ++= sys.env
+  .get("GITHUB_TOKEN")
+  .map { token =>
+    Credentials("GitHub Package Registry", "maven.pkg.github.com", "_", token)
+  }
+  .toSeq
+
+ThisBuild / resolvers ++= githubPackagesRepo.toSeq
+
+ThisBuild / publishTo := githubPackagesRepo.orElse {
   val centralSnapshots =
     "https://central.sonatype.com/repository/maven-snapshots/"
   if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
   else localStaging.value
 }
 
-// CI-only publishing: the signing key hex comes from the PGP_KEY_HEX env var, set by
-// the shared early-effect org secret in the release workflow. There is no real key in
-// this file — the "MISSING_KEY_HEX" sentinel keeps the build loadable for local
-// compile/test but makes signing fail loudly if anyone tries to publish off-CI.
-usePgpKeyHex(sys.env.getOrElse("PGP_KEY_HEX", "MISSING_KEY_HEX"))
+// CI-only Central signing. Fork Packages publishes are unsigned (token auth).
+githubPackagesRepo match {
+  case None    => usePgpKeyHex(sys.env.getOrElse("PGP_KEY_HEX", "MISSING_KEY_HEX"))
+  case Some(_) => Seq.empty
+}
 
-// zipx: Aggregate verify (tests + marklit docs) + Central publish + Scala Steward.
+// zipx: Aggregate verify (tests + marklit on all repos) + dual publish by repo + Steward.
 zipxJavaVersion  := "25"
 zipxScalaSteward := true
-zipxCapabilities += Capability.once("fmt", "scalafmtCheckAll")
-zipxCapabilities += Capability.once(
-  name = "test",
-  command = "test; docs/marklitCompile",
-  needsCapabilities = List("fmt"),
-)
-zipxCapabilities += ZipxCentral.release.copy(command = _ => "+publishSigned; sonaRelease")
-
+zipxCapabilities ++= {
+  val upstream = JobCondition.repositoryIs("early-effect/saferis")
+  Seq(
+    Capability.once("fmt", "scalafmtCheckAll"),
+    Capability.once(
+      name = "test",
+      command = "test; docs/marklitCompile",
+      needsCapabilities = List("fmt"),
+    ),
+    ZipxCentral.release
+      .copy(command = _ => "core/publishSigned; sonaRelease")
+      .withCondition(upstream),
+    ZipxGitHubPackages.sharedRegistry(
+      repository = Some("Iterable/saferis"),
+      packagesRepo = Some("https://maven.pkg.github.com/iterable/maven-packages"),
+      publishOrg = Some("com.iterable"),
+      publishOrgName = Some("Iterable"),
+    ).copy(command = _ => "core/publish"),
+  )
+}
 lazy val commonSettings = Seq(
   scalacOptions ++= Seq(
     "-deprecation",
@@ -99,8 +122,10 @@ lazy val docs = project
   .dependsOn(core)
   .settings(commonSettings)
   .settings(
-    name           := "saferis-docs",
-    publish / skip := true,
+    name            := "saferis-docs",
+    publish / skip  := true,
+    publishArtifact := false,
+    zipxPublish     := Some(false), // never join Central / Packages publish jobs
     libraryDependencies ++= Seq(
       "dev.zio"           %% "zio"        % zioVersion,
       "dev.zio"           %% "zio-json"   % "0.9.0",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,7 @@
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.6.1")
 addSbtPlugin("rocks.earlyeffect" % "sbt-marklit"   % "0.1.0")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.14.7")
-addSbtPlugin("com.github.sbt"    % "sbt-dynver"    % "5.1.1")
+addSbtPlugin("rocks.earlyeffect" % "sbt-dynver-ci" % "0.2.2")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "2.4.4")
-addSbtPlugin("rocks.earlyeffect" % "sbt-zipx"      % "0.0.10")
-
-// zipx bundles sbt-remote-cache; compiler-interface is on both sbt-2.x and zinc-1.x schemes.
-libraryDependencySchemes += "org.scala-sbt" % "compiler-interface" % "always"
+addSbtPlugin("rocks.earlyeffect" % "sbt-zipx"      % "0.0.12")


### PR DESCRIPTION
## Summary
- Bump `sbt-zipx` to **0.0.12** and adopt `sbt-dynver-ci` 0.2.2 (supersedes #53); drop the `compiler-interface` `libraryDependencySchemes` workaround fixed in 0.0.12.
- Regenerate CI: runtime `CacheEpoch.GitTags()`, concurrency, `fetch-tags`.
- Dual publish by repo name:
  - `early-effect/saferis` tags → Central (`core/publishSigned; sonaRelease`, `rocks.earlyeffect`)
  - `Iterable/saferis` tags → GitHub Packages (`core/publish` → `com.iterable` / `iterable/maven-packages`)
- Marklit verify (`test; docs/marklitCompile`) runs on **all** repos; docs is not a Maven artifact.

## Test plan
- [x] `sbt zipxWorkflowCheck` clean
- [x] PR CI: fmt + test (incl. marklit) green on early-effect
- [x] Confirm generated `publish` job `if:` includes `github.repository == 'early-effect/saferis'`
- [x] Confirm generated `github-packages` job `if:` includes `github.repository == 'Iterable/saferis'` and `PUBLISH_ORG=com.iterable`
- [ ] After merge: sync Iterable fork; tag there should hit Packages only (needs `GH_PACKAGES_TOKEN`)
- [ ] Close #53 as superseded