### PR TITLE
Harden Testcontainers CI against Docker Hub flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
       - fmt
       - verify-gate
     if: "!cancelled() && !startsWith(github.ref, 'refs/tags/') && github.event_name != 'workflow_dispatch' && ((needs.verify-gate.result != 'success') || (needs.verify-gate.outputs.run == 'true'))"
+    env:
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -95,6 +97,22 @@ jobs:
             ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.epoch }}-
             ubuntu-latest-jdk25-sbt-${{ steps.cache-epoch.outputs.release }}-
             ubuntu-latest-jdk25-sbt-
+      - name: Pre-pull Postgres image
+        run: |
+          set -euo pipefail
+          image=postgres:latest
+          max=5
+          for attempt in $(seq 1 "$max"); do
+            if docker pull "$image"; then
+              exit 0
+            fi
+            if [ "$attempt" -eq "$max" ]; then
+              echo "Failed to pull $image after $max attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+
       - name: test
         run: sbt 'test; docs/marklitCompile'
   fmt:

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,30 @@ zipxCapabilities ++= {
       name = "test",
       command = "test; docs/marklitCompile",
       needsCapabilities = List("fmt"),
+      // GHA VMs are disposable; skip Ryuk so Hub flakes on testcontainers/ryuk cannot fail CI.
+      env = Map("TESTCONTAINERS_RYUK_DISABLED" -> EnvValue.plain("true")),
+      extraSteps = _ =>
+        List(
+          Step(
+            name = Some("Pre-pull Postgres image"),
+            run = Some(
+              """|set -euo pipefail
+                 |image=postgres:latest
+                 |max=5
+                 |for attempt in $(seq 1 "$max"); do
+                 |  if docker pull "$image"; then
+                 |    exit 0
+                 |  fi
+                 |  if [ "$attempt" -eq "$max" ]; then
+                 |    echo "Failed to pull $image after $max attempts" >&2
+                 |    exit 1
+                 |  fi
+                 |  sleep $((attempt * 10))
+                 |done
+                 |""".stripMargin
+            ),
+          )
+        ),
     ),
     ZipxCentral.release
       .copy(command = _ => "core/publishSigned; sonaRelease")


### PR DESCRIPTION
## Summary
- Disable Testcontainers Ryuk in the CI `test` job (`TESTCONTAINERS_RYUK_DISABLED=true`). GHA VMs are disposable, so Ryuk is unnecessary and its Hub pull was the recent CI failure mode.
- Pre-pull `postgres:latest` with retries before `sbt test` (still using latest, as intended).
- Wired via zipx (`Capability.once` env + `extraSteps`) and regenerated `ci.yml`.

## Test plan
- [ ] Confirm CI `test` job shows the Pre-pull Postgres image step and `TESTCONTAINERS_RYUK_DISABLED` env
- [ ] Confirm integration tests still pass without Ryuk
- [ ] Optionally re-run once if Hub is slow; pre-pull should retry rather than fail the suite mid-flight