### PR TITLE
Hide dynver -ci from Specular install snippets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,5 +178,13 @@ lazy val docs = project
     specularMetaProject   := Some(LocalProject("core")),
     specularArtifactKind  := "library",
     specularSiteDirectory := (ThisBuild / baseDirectory).value / "target" / "site",
+    // Docs-only (workflow_dispatch) builds are dynver `-ci`; don't advertise that as a Central coord.
+    // Empty string → Specular uses build version (clean v* tags).
+    specularDisplayVersion := {
+      val v = (ThisBuild / version).value
+      if v.endsWith("-ci") || v.endsWith("-SNAPSHOT") then
+        previousStableVersion.value.getOrElse("<version>")
+      else ""
+    },
     scalacOptions ~= (_.filterNot(_ == "-Wunused:all")),
   )


### PR DESCRIPTION
## Summary
- Set `specularDisplayVersion` so docs-only / mid-release builds (`*-ci`) show the last stable tag in install chrome, not `0.19.1-ci`
- Same pattern as zipx and mermoid; clean `v*` tags still use the build version

## Test plan
- [ ] `sbt 'show docs / specularDisplayVersion'` → last stable (e.g. `0.19.1`) while version is `*-ci`
- [ ] After merge: CI `workflow_dispatch` regen Pages; install snippet shows `0.19.1` without `-ci`
- [ ] Next `v*` tag deploy still shows the tagged version