### PR TITLE
Add mermoid ascent diagrams to Specular docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ build.sbt.semanticdb
 # Bloop
 .bsp
 
-# VS Code
+# VS Code / Cursor
 .vscode/
+.cursor/
 .scala-build/
 
 # Metals

--- a/saferis-docs/src/test/scala/saferis/docs/Capabilities.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/Capabilities.scala
@@ -29,6 +29,15 @@ object Capabilities extends SaferisDocSpecSuite:
 
 Each dialect mixes in capability traits that enable specific operations:
 
+```mermaid
+flowchart LR
+  dialect[Dialect] --> ret[ReturningSupport]
+  dialect --> json[JsonSupport]
+  dialect --> arr[ArraySupport]
+  dialect --> upsert[UpsertSupport]
+  dialect --> idx[IndexIfNotExists]
+```
+
 | Trait | Operations Enabled |
 |-------|-------------------|
 | `ReturningSupport` | `insertReturning`, `updateReturning`, `deleteReturning` |

--- a/saferis-docs/src/test/scala/saferis/docs/GettingStarted.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/GettingStarted.scala
@@ -52,6 +52,13 @@ it, all type-safe, all against a real database:""",
 `ZIOAppDefault` run the program: `xa.run(...)` turns a database program into an
 ordinary `ZIO` effect:
 
+```mermaid
+flowchart TB
+  ds[DataSource] --> cp[ConnectionProvider]
+  cp --> xa[Transactor.layer]
+  xa --> prog[xa.run ZIO program]
+```
+
 ```scala
 import saferis.*
 import zio.*

--- a/saferis-docs/src/test/scala/saferis/docs/PagedStreaming.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/PagedStreaming.scala
@@ -37,6 +37,17 @@ object PagedStreaming extends SaferisDocSpecSuite:
   def doc = page("Paged Streaming")(
     md"""Paged streaming provides **cursor-based pagination with automatic connection release between pages**. Unlike `queryStream` which holds a single connection open for the entire stream, paged streaming fetches data in batches and releases the connection after each batch. This makes it ideal for:
 
+```mermaid
+flowchart TB
+  qs[queryStream] --> qa[acquire]
+  qa --> qh[hold open]
+  qh --> qr[release at end]
+  ps[pagedStream] --> pf[fetch page]
+  pf --> pr[release]
+  pr --> pc[checkpoint]
+  pc --> pre[resume]
+```
+
 - **Long-running processing** - Process millions of rows without holding database connections
 - **Resumable operations** - Checkpoint your position and resume after failures
 - **Resource efficiency** - Free connections for other operations between page fetches

--- a/saferis-docs/src/test/scala/saferis/docs/QueryBuilder.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/QueryBuilder.scala
@@ -45,6 +45,16 @@ object QueryBuilder extends SaferisDocSpecSuite:
     section("Query Safety (Builder/Ready Pattern)")(
       md"""To prevent accidental unbounded queries that could fetch millions of rows, Saferis uses a **Builder/Ready pattern**. A query must have at least one safety constraint before it can be executed:
 
+```mermaid
+stateDiagram-v2
+  [*] --> Builder
+  Builder --> Ready: where
+  Builder --> Ready: limit
+  Builder --> Ready: seek
+  Builder --> Ready: all
+  Ready --> [*]: execute
+```
+
 | Safety Constraint | Description |
 |------------------|-------------|
 | `.where(...)` | Filter results with a WHERE clause |

--- a/saferis-docs/src/test/scala/saferis/docs/SchemaValidation.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/SchemaValidation.scala
@@ -37,7 +37,17 @@ object SchemaValidation extends SaferisDocSpecSuite:
   case class StartupOrder(@generated @key id: Int, customerId: Int, amount: BigDecimal) derives Table
 
   def doc = page("Schema Validation")(
-    md"""Saferis provides runtime schema validation to verify that your table definitions match the actual database schema. This is useful for detecting schema drift, validating migrations, and ensuring consistency between code and database.""",
+    md"""Saferis provides runtime schema validation to verify that your table definitions match the actual database schema. This is useful for detecting schema drift, validating migrations, and ensuring consistency between code and database.
+
+```mermaid
+flowchart TB
+  schema[Scala Schema] --> ddl[ddl.createTable]
+  ddl --> db[(live DB)]
+  db --> verify[Schema.verify]
+  verify --> pass[pass]
+  verify --> issues[SchemaIssues]
+```
+""",
     section("Basic Verification")(
       md"""Use `Schema(instance).verify` to validate a schema against the database:""",
       exampleZIO {

--- a/saferis-docs/src/test/scala/saferis/docs/SqlInjectionPrevention.scala
+++ b/saferis-docs/src/test/scala/saferis/docs/SqlInjectionPrevention.scala
@@ -28,7 +28,22 @@ object SqlInjectionPrevention extends SaferisDocSpecSuite:
 
 ## How the `sql"..."` Interpolator Works
 
-The interpolator analyzes each interpolated expression at compile time and routes it appropriately:""",
+The interpolator analyzes each interpolated expression at compile time and routes it appropriately:
+
+```mermaid
+flowchart LR
+  splice[sql splice] --> values[Scala values]
+  splice --> tables[Table or columns]
+  splice --> alias[Alias]
+  splice --> ident[Placeholder.identifier]
+  splice --> raw[Placeholder.raw]
+  values --> binds[param binds]
+  tables --> sqlText[SQL text]
+  alias --> literal[compile-time literal]
+  ident --> escaped[escaped identifier]
+  raw --> hatch[escape hatch]
+```
+""",
     exampleValue {
       val userName = "Alice"
       sql"SELECT * FROM $users WHERE ${users.name} = $userName".sql


### PR DESCRIPTION
## Summary
- Add fenced Mermaid diagrams (ascent hybrid via specular-mermoid) to six high-value DocSpecs: Getting Started, SQL Injection Prevention, Capabilities, Query Builder, Paged Streaming, and Schema Validation.
- Diagrams cover app wiring, interpolator splice routing, dialect capability gating, Builder/Ready safety, streaming connection lifecycles, and schema verify flow.
- No new dependencies; Specular already renders `mermaid` fences through `Mermoid.diagram`.

## Test plan
- [ ] `sbt docs/specularSite` succeeds (bad Mermaid fails the build)
- [ ] Spot-check the six pages for `.mermoid-node` / `.mermoid-edges` (ascent hybrid, not a code fence)
- [ ] Confirm diagrams fit the content column without horizontal overflow