### PR TITLE
Add scalafmt pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reject commits that would fail CI's scalafmtCheckAll.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# Cursor agent seatbelt blocks sbt's client socket / ~/.sbt; CI still runs scalafmtCheckAll.
+if [ "${CURSOR_SANDBOX:-}" = "seatbelt" ]; then
+  echo "pre-commit: skipping scalafmtCheckAll under Cursor agent sandbox (CI enforces it)."
+  exit 0
+fi
+
+if ! command -v sbt >/dev/null 2>&1; then
+  echo "pre-commit: sbt not found on PATH; cannot run scalafmtCheckAll" >&2
+  exit 1
+fi
+
+echo "pre-commit: running sbt scalafmtCheckAll (same gate as CI)…"
+if ! sbt -batch -no-colors scalafmtCheckAll; then
+  echo >&2
+  echo "pre-commit: BLOCKED; scalafmtCheckAll failed." >&2
+  echo "  Fix with:  sbt scalafmtAll && git add -u" >&2
+  echo "  Then commit again." >&2
+  exit 1
+fi
+
+echo "pre-commit: OK; scalafmtCheckAll passed."

--- a/README.md
+++ b/README.md
@@ -57,3 +57,9 @@ The documentation is built with [Specular](https://github.com/early-effect/specu
 ## License
 
 [Apache 2.0](LICENSE)
+
+## Development
+
+```bash
+./scripts/install-git-hooks  # once per clone: pre-commit runs scalafmtCheckAll
+```

--- a/scripts/install-git-hooks
+++ b/scripts/install-git-hooks
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Install repo git hooks (sets core.hooksPath to .githooks for this clone only).
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+git config --local core.hooksPath .githooks
+chmod +x .githooks/pre-commit
+
+echo "Installed git hooks from .githooks (core.hooksPath=.githooks)"
+echo "pre-commit will run: sbt scalafmtCheckAll"


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-commit` that runs `sbt scalafmtCheckAll` (same gate as CI)
- Add `./scripts/install-git-hooks` to set `core.hooksPath=.githooks` for this clone
- Document the one-time install in the README where missing

## Test plan
- [ ] `./scripts/install-git-hooks`
- [ ] Intentionally break formatting and confirm commit is blocked
- [ ] `sbt scalafmtAll` then commit succeeds