### PR TITLE
Bump sbt to 2.0.6 (GHSA-m2pw-22cj-jq4v) and combine dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -163,7 +163,7 @@ lazy val docs = project
   .settings(commonSettings)
   .settings(
     name := "saferis-docs",
-    // Specular 0.11.0 is built on 3.8.x; keep published core on ThisBuild LTS (3.3.8).
+    // Specular 0.12.0 is built on 3.8.x; keep published core on ThisBuild LTS (3.3.8).
     scalaVersion    := "3.8.4",
     publish / skip  := true,
     publishArtifact := false,

--- a/build.sbt
+++ b/build.sbt
@@ -154,7 +154,7 @@ lazy val core = project
     ),
   )
 
-val specularVersion = "0.11.0"
+val specularVersion = "0.12.0"
 
 lazy val docs = project
   .in(file("saferis-docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -171,7 +171,7 @@ lazy val docs = project
     libraryDependencies ++= Seq(
       "dev.zio"           %% "zio"                     % zioVersion,
       "dev.zio"           %% "zio-streams"             % zioVersion,
-      "dev.zio"           %% "zio-json"                % "0.9.0",
+      "dev.zio"           %% "zio-json"                % "0.9.2",
       "dev.zio"           %% "zio-test"                % zioVersion      % Test,
       "dev.zio"           %% "zio-test-sbt"            % zioVersion      % Test,
       "rocks.earlyeffect" %% "specular-core"           % specularVersion % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=2.0.5
+sbt.version=2.0.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.6.2")
-addSbtPlugin("rocks.earlyeffect" % "sbt-specular"  % "0.11.0")
+addSbtPlugin("rocks.earlyeffect" % "sbt-specular"  % "0.12.0")
 addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.14.7")
 addSbtPlugin("rocks.earlyeffect" % "sbt-dynver-ci" % "0.2.2")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"       % "2.3.1")


### PR DESCRIPTION
sbt 2.0.6 fixes GHSA-m2pw-22cj-jq4v: with `serverConnectionType` set to `Tcp`, an
attacker can execute arbitrary code remotely via the sbt server. This repo does not
set that option, so this is toolchain hygiene rather than active exposure.

Combines the open Scala Steward PRs into one branch so CI runs once. The bot PRs
never get a CI run of their own: they are authored with `GITHUB_TOKEN`, which does
not trigger workflows, so their required checks never report and they sit blocked.

Replaces:
- #76 Minor and patch updates (sbt 2.0.5 to 2.0.6)
- #75 Update ZIO dependencies (zio-json 0.9.0 to 0.9.2)
- #74 Update early-effect dependencies (sbt-specular and specular-core 0.11.0 to 0.12.0)

No strict-eviction fix needed: zio-json 0.9.0 to 0.9.2 is a patch bump within the
same early-semver line, so nothing had to be forced.

## Verification
Local, on this branch:
- `zipxWorkflowCheck`: up to date
- `scalafmtCheckAll`: clean
- `testFull`: 556 tests passed, 0 failed